### PR TITLE
Fix an issue where the error handler prover was asking for a dependency before being defined

### DIFF
--- a/node/errorHandler.js
+++ b/node/errorHandler.js
@@ -88,17 +88,19 @@ class ErrorHandler {
  * @return {Provider}
  */
 const errorHandlerWithOptions = (exitOnError) => provider((app) => {
-  let logger = null;
-  try {
-    logger = app.get('logger');
-  } catch (ignore) {
-    logger = app.get('appLogger');
-  }
+  app.set('errorHandler', () => {
+    let logger = null;
+    try {
+      logger = app.get('logger');
+    } catch (ignore) {
+      logger = app.get('appLogger');
+    }
 
-  app.set('errorHandler', () => new ErrorHandler(
-    logger,
-    exitOnError
-  ));
+    return new ErrorHandler(
+      logger,
+      exitOnError
+    );
+  });
 });
 /**
  * The service provider that once registered on the app container will set an instance of


### PR DESCRIPTION
### What does this PR do?

On #1 I made the error handler provider depend on the `logger` service by default and then fallback to `appLogger` if `logger` wasn't available.... the problem is that I added the `trycatch` logic outside the `.set` method, so it was being executed when the service was being registered... killing the lazy loading.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```