### PR TITLE
Add support for multiple event names

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,19 +103,19 @@ Before doing anything, install the repository hooks:
 
 ```bash
 # You can either use npm or yarn, it doesn't matter
-npm run install-hooks
+yarn run hooks
 ```
 
 ### NPM/Yarn Tasks
 
-| Task                    | Description                         |
-|-------------------------|-------------------------------------|
-| `npm run install-hooks` | Install the GIT repository hooks.   |
-| `npm test`              | Run the project unit tests.         |
-| `npm run lint`          | Lint the modified files.            |
-| `npm run lint:full`     | Lint the project code.              |
-| `npm run docs`          | Generate the project documentation. |
-| `npm run todo`          | List all the pending to-do's.       |
+| Task                     | Description                         |
+|--------------------------|-------------------------------------|
+| `yarn run install-hooks` | Install the GIT repository hooks.   |
+| `yarn test`              | Run the project unit tests.         |
+| `yarn run lint`          | Lint the modified files.            |
+| `yarn run lint:full`     | Lint the project code.              |
+| `yarn run docs`          | Generate the project documentation. |
+| `yarn run todo`          | List all the pending to-do's.       |
 
 ### Testing
 

--- a/documents/shared/eventsHub.md
+++ b/documents/shared/eventsHub.md
@@ -43,6 +43,29 @@ events.on('user-login', (username, password) => {
 events.emit('user-login', 'rosario', 'p4ssword');
 ```
 
+And you can even use the same listener for multiple events:
+
+```js
+// Add the listener
+events.on(['logout-route', 'unauthorized-request'], () => {
+  someAuthService.signout();
+});
+
+...
+
+events.emit('logout-route');
+// or
+someRequest()
+.then(() => ... )
+.catch((error) => {
+  if (error.code === 401) {
+    events.emit('unauthorized-request');
+  }
+})
+```
+
+> All methods that support an event name also support an `Array` with a list of them.
+
 ### Reduce a variable
 
 It's basically the same as calling `emit`, but the first parameter may be modified by the listeners and it's returned after it went through all of them.

--- a/documents/shared/eventsHub.md
+++ b/documents/shared/eventsHub.md
@@ -18,7 +18,7 @@ const events = new EventsHub();
 ```js
 // Add the listener
 events.on('my-event', () => {
-  console.log('The event listener was called!);
+  console.log('The event listener was called!');
 });
 // Emit the event
 events.emit('my-event');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A set of Javascript utilities for building Node and browser apps.",
   "homepage": "https://homer0.github.io/wootils/",
   "scripts": {
-    "install-hooks": "./utils/hooks/install",
+    "hooks": "./utils/hooks/install",
     "test": "./utils/scripts/test",
     "lint": "./utils/scripts/lint",
     "lint:full": "./utils/scripts/lint-full",

--- a/shared/eventsHub.js
+++ b/shared/eventsHub.js
@@ -142,7 +142,17 @@ class EventsHub {
 
     return this._events[event];
   }
-
+  /**
+   * Check whether a subscriber should be removed or not. When a function subscribes to be executed
+   * only `once` per event, it gets a property that tracks the events for which the function
+   * should be executed for, and if this method detects that all those executions where done,
+   * it return `true` so the method that called can remove it from the subscribers list.
+   * @param {string}   event      The name of the event the function was just executed for.
+   * @param {Function} subscriber The subscriber function.
+   * @return {boolean}            Whether or not the function should be removed.
+   * @access protected
+   * @ignore
+   */
   _shouldRemoveSubscriber(event, subscriber) {
     let should = false;
     if (subscriber.once) {

--- a/shared/eventsHub.js
+++ b/shared/eventsHub.js
@@ -16,94 +16,117 @@ class EventsHub {
   }
   /**
    * Adds a new event listener.
-   * @param {String}   event The name of the event.
-   * @param {Function} fn    The listener function.
-   * @return {Function} An unsubscribe function to remove the listener.
+   * @param {String|Array} event An event name or a list of them.
+   * @param {Function}     fn    The listener function.
+   * @return {Function} An unsubscribe function to remove the listener or listeners.
    */
   on(event, fn) {
-    const subscribers = this.subscribers(event);
-    if (!subscribers.includes(fn)) {
-      subscribers.push(fn);
-    }
+    const events = Array.isArray(event) ? event : [event];
+    events.forEach((name) => {
+      const subscribers = this.subscribers(name);
+      if (!subscribers.includes(fn)) {
+        subscribers.push(fn);
+      }
+    });
 
     return () => this.off(event, fn);
   }
   /**
    * Adds an event listener that will only be executed once.
-   * @param {String}   event The name of the event.
-   * @param {Function} fn    The listener function.
+   * @param {String|Array} event An event name or a list of them.
+   * @param {Function}     fn    The listener function.
    * @return {Function} An unsubscribe function to remove the listener.
    */
   once(event, fn) {
+    const events = Array.isArray(event) ? event : [event];
+    const once = {};
+    events.forEach((name) => {
+      once[name] = true;
+    });
+
     // eslint-disable-next-line no-param-reassign
-    fn.once = true;
+    fn.once = once;
     return this.on(event, fn);
   }
   /**
    * Removes an event listener.
-   * @param {String}   event The name of the event.
-   * @param {Function} fn    The listener function.
-   * @return {Boolean} Whether or not the listener was found and removed.
+   * @param {String|Array} event An event name or a list of them.
+   * @param {Function}     fn    The listener function.
+   * @return {Boolean|Array} If `event` was a `string`, it will return whether or not the listener
+   *                         was found and removed; but if `event` was an `Array`, it will return
+   *                         a list of boolean values.
    */
   off(event, fn) {
-    const subscribers = this.subscribers(event);
-    const index = subscribers.indexOf(fn);
-    let result = false;
-    if (index > -1) {
-      result = true;
-      subscribers.splice(index, 1);
-    }
+    const isArray = Array.isArray(event);
+    const events = isArray ? event : [event];
+    const result = events.map((name) => {
+      const subscribers = this.subscribers(name);
+      let found = false;
+      const index = subscribers.indexOf(fn);
+      if (index > -1) {
+        found = true;
+        subscribers.splice(index, 1);
+      }
 
-    return result;
+      return found;
+    });
+
+    return isArray ? result : result[0];
   }
   /**
    * Emits an event and call all its listeners.
-   * @param {String} event The name of the event.
-   * @param {Array}  args  A list of parameters to send to the listeners.
+   * @param {String|Array} event An event name or a list of them.
+   * @param {Array}        args  A list of parameters to send to the listeners.
    */
   emit(event, ...args) {
     const toClean = [];
-    this.subscribers(event).forEach((subscriber) => {
-      subscriber(...args);
-      if (subscriber.once) {
-        toClean.push(subscriber);
-      }
+    const events = Array.isArray(event) ? event : [event];
+    events.forEach((name) => {
+      this.subscribers(name).forEach((subscriber) => {
+        subscriber(...args);
+        if (this._shouldRemoveSubscriber(name, subscriber) && !toClean.includes(subscriber)) {
+          toClean.push(subscriber);
+        }
+      });
     });
 
-    toClean.forEach((subscriber) => this.off(event, subscriber));
+    toClean.forEach((subscriber) => this.off(Object.keys(subscriber.once), subscriber));
   }
   /**
    * Reduce a target using an event. It's like emit, but the events listener return
    * a modified (or not) version of the `target`.
-   * @param {String} event  The name of the event.
-   * @param {*}      target The variable to reduce with the listeners.
-   * @param {Array}  args   A list of parameters to send to the listeners.
+   * @param {String|Array} event  An event name or a list of them.
+   * @param {*}            target The variable to reduce with the listeners.
+   * @param {Array}        args   A list of parameters to send to the listeners.
    * @return {*} A version of the `target` processed by the listeners.
    */
   reduce(event, target, ...args) {
-    const subscribers = this.subscribers(event);
+    const events = Array.isArray(event) ? event : [event];
     let result = target;
-    if (subscribers.length) {
-      const toClean = [];
-      let processed;
-      if (Array.isArray(target)) {
-        processed = target.slice();
-      } else if (typeof target === 'object') {
-        processed = Object.assign({}, target);
-      } else {
-        processed = target;
-      }
-
-      this.subscribers(event).forEach((subscriber) => {
-        processed = subscriber(...[processed, ...args]);
-        if (subscriber.once) {
-          toClean.push(subscriber);
+    events.forEach((name) => {
+      const subscribers = this.subscribers(name);
+      if (subscribers.length) {
+        const toClean = [];
+        let processed;
+        if (Array.isArray(result)) {
+          processed = result.slice();
+        } else if (typeof result === 'object') {
+          processed = Object.assign({}, result);
+        } else {
+          processed = result;
         }
-      });
 
-      toClean.forEach((subscriber) => this.off(event, subscriber));
-      result = processed;
-    }
+        subscribers.forEach((subscriber) => {
+          processed = subscriber(...[processed, ...args]);
+          if (this._shouldRemoveSubscriber(name, subscriber)) {
+            toClean.push(subscriber);
+          }
+        });
+
+        toClean.forEach((subscriber) => this.off(Object.keys(subscriber.once), subscriber));
+        result = processed;
+      }
+    });
 
     return result;
   }
@@ -118,6 +141,16 @@ class EventsHub {
     }
 
     return this._events[event];
+  }
+
+  _shouldRemoveSubscriber(event, subscriber) {
+    let should = false;
+    if (subscriber.once) {
+      // eslint-disable-next-line no-param-reassign
+      subscriber.once[event] = false;
+      should = !Object.keys(subscriber.once).some((name) => subscriber.once[name]);
+    }
+    return should;
   }
 }
 

--- a/tests/shared/eventsHub.test.js
+++ b/tests/shared/eventsHub.test.js
@@ -117,8 +117,8 @@ describe('EventsHub', () => {
     // When
     const sut = new EventsHub();
     sut.once(eventNames, subscriber);
-    sut.emit(eventNames, subscriber);
-    sut.emit(eventNames, subscriber);
+    sut.emit(eventNames);
+    sut.emit(eventNames);
     // Then
     expect(subscriber).toHaveBeenCalledTimes(eventNames.length);
   });
@@ -132,8 +132,33 @@ describe('EventsHub', () => {
     // When
     const sut = new EventsHub();
     sut.once(eventNames, subscriber);
-    eventNames.forEach((eventName) => sut.emit(eventName, subscriber));
-    eventNames.forEach((eventName) => sut.emit(eventName, subscriber));
+    eventNames.forEach((eventName) => sut.emit(eventName));
+    eventNames.forEach((eventName) => sut.emit(eventName));
+    // Then
+    expect(subscriber).toHaveBeenCalledTimes(eventNames.length);
+  });
+
+  it('shouldn\'t unsubscribe a subscriber until it gets executed on all the events', () => {
+    // Given
+    const eventOneName = 'FIRST EVENT';
+    const eventTwoName = 'SECOND EVENT';
+    const eventNames = [eventOneName, eventTwoName];
+    const subscriber = jest.fn();
+    // When
+    const sut = new EventsHub();
+    sut.once(eventNames, subscriber);
+    sut.emit(eventOneName);
+    sut.emit(eventOneName);
+    sut.emit(eventOneName);
+    sut.emit(eventOneName);
+    sut.emit(eventOneName);
+    sut.emit(eventOneName);
+    sut.emit(eventTwoName);
+    sut.emit(eventNames);
+    sut.emit(eventTwoName);
+    sut.emit(eventTwoName);
+    sut.emit(eventTwoName);
+    sut.emit(eventOneName);
     // Then
     expect(subscriber).toHaveBeenCalledTimes(eventNames.length);
   });

--- a/utils/hooks/install
+++ b/utils/hooks/install
@@ -1,10 +1,10 @@
-#!/bin/sh
+#!/bin/sh -e
 if [ -d ".git" ]; then
     ln -sv ../../utils/hooks/pre-commit.local ./.git/hooks/pre-commit
     ln -sv ../../utils/hooks/post-merge.local ./.git/hooks/post-merge
-    echo "Hooks installed"
+    echo "\033[92mHooks installed!"
     exit 0
 fi
 
-echo ".git directory not found"
+echo -e "\033[31m.git directory not found"
 exit 1


### PR DESCRIPTION
### What does this PR do?

All the methods on the `EventsHub` that required an event name now support an `Array` with a list of them, so you can now listen, emit and reduce multiple events at once:

```js
// Listen
events.on(['event-one', 'event-two'], (...args) => { });

// Listen once
events.once(['event-one', 'event-two'], (...args) => {});

// Emit
events.emit(['event-one', 'event-two'], ...args);

// Reduce
events.reduce(['event-one', 'event-two'], target, ...args);

// Remove
events.off(['event-one', 'event-two'], (...args) => { });
```

> Small note on the `once`: If you add it for, let's say, 2 events

Also, I changed the `install-hooks` script for just `hooks`... This is only for development, so I don't consider it a breaking change.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```