### PR TITLE
Add missing documents to the generated ESDoc site

### DIFF
--- a/.esdoc.json
+++ b/.esdoc.json
@@ -15,7 +15,10 @@
             "./documents/node/logger.md",
             "./documents/node/packageInfo.md",
             "./documents/node/pathUtils.md",
-            "./documents/node/rootRequire.md"
+            "./documents/node/rootRequire.md",
+            "./documents/shared/APIClient.md",
+            "./documents/shared/deferred.md",
+            "./documents/shared/eventsHub.md"
           ]
         }
       }

--- a/README-esdoc.md
+++ b/README-esdoc.md
@@ -103,19 +103,19 @@ Before doing anything, install the repository hooks:
 
 ```bash
 # You can either use npm or yarn, it doesn't matter
-npm run install-hooks
+yarn run hooks
 ```
 
 ### NPM/Yarn Tasks
 
-| Task                    | Description                         |
-|-------------------------|-------------------------------------|
-| `npm run install-hooks` | Install the GIT repository hooks.   |
-| `npm test`              | Run the project unit tests.         |
-| `npm run lint`          | Lint the modified files.            |
-| `npm run lint:full`     | Lint the project code.              |
-| `npm run docs`          | Generate the project documentation. |
-| `npm run todo`          | List all the pending to-do's.       |
+| Task                     | Description                         |
+|--------------------------|-------------------------------------|
+| `yarn run hooks`         | Install the GIT repository hooks.   |
+| `yarn test`              | Run the project unit tests.         |
+| `yarn run lint`          | Lint the modified files.            |
+| `yarn run lint:full`     | Lint the project code.              |
+| `yarn run docs`          | Generate the project documentation. |
+| `yarn run todo`          | List all the pending to-do's.       |
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ yarn run hooks
 
 | Task                     | Description                         |
 |--------------------------|-------------------------------------|
-| `yarn run install-hooks` | Install the GIT repository hooks.   |
+| `yarn run hooks`         | Install the GIT repository hooks.   |
 | `yarn test`              | Run the project unit tests.         |
 | `yarn run lint`          | Lint the modified files.            |
 | `yarn run lint:full`     | Lint the project code.              |


### PR DESCRIPTION
### What does this PR do?

Links the documents for the _"shared modules"_.

### How should it be tested manually?

There are no changes on functionality, so everything should be working as it was before.