### PR TITLE
Add a .patch method for the APIClient and fix how it handles a request body.

### DIFF
--- a/documents/shared/APIClient.md
+++ b/documents/shared/APIClient.md
@@ -132,6 +132,7 @@ On the example above we saw only `.get` and `.post`, but the client comes with t
 - `.get(url, options = {})`
 - `.post(url, body, options = {})`
 - `.put(url, body, options = {})`
+- `.patch(url, body, options = {})`
 - `.delete(url, body = {}, options = {})`
 
 If you are wondering what `options` are, well, they are extra options for the `fetch` client call. It can include headers, another method, another body, etc. Everything that could send on the `fetch` call second parameter.

--- a/shared/apiClient.js
+++ b/shared/apiClient.js
@@ -333,14 +333,23 @@ class APIClient {
     delete opts.url;
     // If the options include a body...
     if (opts.body) {
-      // ...encode it.
-      opts.body = JSON.stringify(opts.body);
-      // Push an empty object if there are no headers...
-      if (!opts.headers) {
+      // Let's first check if there are headers and if a `Content-Type` has been set.
+      let hasContentType = false;
+      if (opts.headers) {
+        hasContentType = Object.keys(opts.headers)
+        .find((name) => name.toLowerCase() === 'content-type');
+      } else {
         opts.headers = {};
       }
-      // ...in order to add the `Content-Type` header.
-      opts.headers['Content-Type'] = 'application/json';
+      // If the body is an object...
+      if (typeof opts.body === 'object') {
+        // ...encode it.
+        opts.body = JSON.stringify(opts.body);
+        // And if no `Content-Type` was defined, let's assume is a JSON request.
+        if (!hasContentType) {
+          opts.headers['Content-Type'] = 'application/json';
+        }
+      }
     }
 
     let responseStatus;

--- a/shared/apiClient.js
+++ b/shared/apiClient.js
@@ -206,6 +206,16 @@ class APIClient {
     return this.post(url, body, Object.assign({}, options, { method: 'put' }));
   }
   /**
+   * Makes a `PATCH` request.
+   * @param {String}       url          The request URL.
+   * @param {Object}       body         The request body.
+   * @param {FetchOptions} [options={}] The request options.
+   * @return {Promise<Object,Error>}
+   */
+  patch(url, body, options = {}) {
+    return this.post(url, body, Object.assign({}, options, { method: 'patch' }));
+  }
+  /**
    * Makes a `DELETE` request.
    * @param {String}       url          The request URL.
    * @param {Object}       body         The request body.

--- a/tests/shared/apiClient.test.js
+++ b/tests/shared/apiClient.test.js
@@ -477,6 +477,77 @@ describe('APIClient', () => {
     });
   });
 
+  it('shouldn\'t overwrite the content type if it was already set', () => {
+    // Given
+    const requestURL = 'http://example.com';
+    const requestMethod = 'post';
+    const requestBody = {
+      prop: 'value',
+    };
+    const requestResponseData = {
+      message: 'hello-world',
+    };
+    const requestResponse = {
+      status: 200,
+      json: jest.fn(() => Promise.resolve(requestResponseData)),
+    };
+    const fetchClient = jest.fn(() => Promise.resolve(requestResponse));
+    const headers = {
+      'Content-Type': 'application/charito',
+    };
+    let sut = null;
+    // When
+    sut = new APIClient('', '', fetchClient);
+    return sut.post(requestURL, requestBody, { headers })
+    .then((response) => {
+      // Then
+      expect(response).toEqual(requestResponseData);
+      expect(requestResponse.json).toHaveBeenCalledTimes(1);
+      expect(fetchClient).toHaveBeenCalledTimes(1);
+      expect(fetchClient).toHaveBeenCalledWith(requestURL, {
+        headers,
+        method: requestMethod.toUpperCase(),
+        body: JSON.stringify(requestBody),
+      });
+    })
+    .catch((error) => {
+      throw error;
+    });
+  });
+
+  it('shouldn\'t overwrite the content type nor encode the body if is not an object', () => {
+    // Given
+    const requestURL = 'http://example.com';
+    const requestMethod = 'post';
+    const requestBody = 'Hello Charito!';
+    const requestResponseData = {
+      message: 'hello-world',
+    };
+    const requestResponse = {
+      status: 200,
+      json: jest.fn(() => Promise.resolve(requestResponseData)),
+    };
+    const fetchClient = jest.fn(() => Promise.resolve(requestResponse));
+    let sut = null;
+    // When
+    sut = new APIClient('', '', fetchClient);
+    return sut.post(requestURL, requestBody)
+    .then((response) => {
+      // Then
+      expect(response).toEqual(requestResponseData);
+      expect(requestResponse.json).toHaveBeenCalledTimes(1);
+      expect(fetchClient).toHaveBeenCalledTimes(1);
+      expect(fetchClient).toHaveBeenCalledWith(requestURL, {
+        headers: {},
+        method: requestMethod.toUpperCase(),
+        body: requestBody,
+      });
+    })
+    .catch((error) => {
+      throw error;
+    });
+  });
+
   it('should make a successfully PUT request using the shortcut method', () => {
     // Given
     const requestURL = 'http://example.com';

--- a/tests/shared/apiClient.test.js
+++ b/tests/shared/apiClient.test.js
@@ -514,6 +514,43 @@ describe('APIClient', () => {
     });
   });
 
+  it('should make a successfully PATCH request using the shortcut method', () => {
+    // Given
+    const requestURL = 'http://example.com';
+    const requestMethod = 'patch';
+    const requestBody = {
+      prop: 'value',
+    };
+    const requestResponseData = {
+      message: 'hello-world',
+    };
+    const requestResponse = {
+      status: 200,
+      json: jest.fn(() => Promise.resolve(requestResponseData)),
+    };
+    const fetchClient = jest.fn(() => Promise.resolve(requestResponse));
+    let sut = null;
+    // When
+    sut = new APIClient('', '', fetchClient);
+    return sut.patch(requestURL, requestBody)
+    .then((response) => {
+      // Then
+      expect(response).toEqual(requestResponseData);
+      expect(requestResponse.json).toHaveBeenCalledTimes(1);
+      expect(fetchClient).toHaveBeenCalledTimes(1);
+      expect(fetchClient).toHaveBeenCalledWith(requestURL, {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        method: requestMethod.toUpperCase(),
+        body: JSON.stringify(requestBody),
+      });
+    })
+    .catch((error) => {
+      throw error;
+    });
+  });
+
   it('should make a successfully DELETE request using the shortcut method', () => {
     // Given
     const requestURL = 'http://example.com';


### PR DESCRIPTION
### What does this PR do?

First, the "feature", a new `patch(url, body, options = {})` method was added on the API client.

Now, there was a kind-of-bug on the APIClient: If your request had a `body`, the service would automatically transform it with `JSON.stringify` and it would also set the `Content-Type` header to `application/json`... but what happens if you wanted to send a `application/x-www-form-urlencoded` or something like that?

The fix was easy, I added two new rules to the process:

1. It will only run `JSON.stringify` if the `body` is an `Object`.
2. It will only set the `Content-Type` if is not already set.

### How should it be tested manually?

Try to make a URL encoded form request.

And of course...

```bash
npm test
# or
yarn test
```