### PR TITLE
v1.3.2: Fix ESLint errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,8 @@
     "arrow-parens": ["error", "always"],
     "import/no-unresolved": "off",
     "import/no-extraneous-dependencies": "off",
-    "no-plusplus": "off"
+    "no-plusplus": "off",
+    "lines-between-class-members": "off",
+    "operator-linebreak": ["error", "after"]
   }
 }

--- a/node/rootRequire.js
+++ b/node/rootRequire.js
@@ -4,10 +4,9 @@ const { provider } = require('jimple');
  * @param {PathUtils} pathUtils To build the path to the files it will `require`.
  * @return {Function(string):*}
  */
-const rootRequire = (pathUtils) =>
-  (path) =>
-    // eslint-disable-next-line global-require,import/no-dynamic-require
-    require(pathUtils.join(path));
+const rootRequire = (pathUtils) => (path) =>
+  // eslint-disable-next-line global-require,import/no-dynamic-require,implicit-arrow-linebreak
+  require(pathUtils.join(path));
 
 /**
  * The service provider that once registered on the app container will set the result of

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wootils",
   "description": "A set of Javascript utilities for building Node and browser apps.",
   "homepage": "https://homer0.github.io/wootils/",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "repository": "homer0/wootils",
   "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
   "license": "MIT",


### PR DESCRIPTION
### What does this PR do?

On #11 I updated the ESLint presets, but because the only modified file were the `package.json` and the `yarn.lock`, the new rules were never tested.

This PR fixes all the lint errors.

### How should it be tested manually?

```bash
npm test && npm run lint:full
# or
yarn test && yarn run lint:full
```
