### PR TITLE
Support for HEAD requests on the API client

### DIFF
--- a/documents/shared/APIClient.md
+++ b/documents/shared/APIClient.md
@@ -130,6 +130,7 @@ This allows you to organize the scopes of your endpoints and make the configurat
 On the example above we saw only `.get` and `.post`, but the client comes with these already built-in request methods:
 
 - `.get(url, options = {})`
+- `.head(url, options = {})`
 - `.post(url, body, options = {})`
 - `.put(url, body, options = {})`
 - `.patch(url, body, options = {})`

--- a/shared/apiClient.js
+++ b/shared/apiClient.js
@@ -182,6 +182,15 @@ class APIClient {
     return this.fetch(Object.assign({ url }, options));
   }
   /**
+   * Makes a `HEAD` request.
+   * @param {String}       url          The request URL.
+   * @param {FetchOptions} [options={}] The request options.
+   * @return {Promise<Object,Error>}
+   */
+  head(url, options = {}) {
+    return this.get(url, Object.assign({}, options, { method: 'head' }));
+  }
+  /**
    * Makes a `POST` request.
    * @param {String}       url          The request URL.
    * @param {Object}       body         The request body.

--- a/tests/shared/apiClient.test.js
+++ b/tests/shared/apiClient.test.js
@@ -655,4 +655,28 @@ describe('APIClient', () => {
       throw error;
     });
   });
+  
+  it('should make a successfully HEAD request using the shortcut method', () => {
+    // Given
+    const requestURL = 'http://example.com';
+    const requestMethod = 'head';
+    const requestResponse = {
+      status: 200,
+    };
+    const fetchClient = jest.fn(() => Promise.resolve(requestResponse));
+    let sut = null;
+    // When
+    sut = new APIClient('', '', fetchClient);
+    return sut.head(requestURL)
+    .then(() => {
+      // Then
+      expect(fetchClient).toHaveBeenCalledTimes(1);
+      expect(fetchClient).toHaveBeenCalledWith(requestURL, {
+        method: requestMethod.toUpperCase(),
+      });
+    })
+    .catch((error) => {
+      throw error;
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?
* Adds support for `HEAD` requests on the API client.

### How should it be tested manually?
```js
const postsUrl = 'https://www.yourapi.com/posts';

// check for posts availability
client.head(postsUrl).then(() => {
  // actual request to get them
  client.get(postsUrl).then((posts) => {
    // do what you want with posts
  });
});
```