### PR TITLE
Specify whether to JSON decode an API Client response or not

### DIFF
--- a/shared/apiClient.js
+++ b/shared/apiClient.js
@@ -6,9 +6,10 @@ const urijs = require('urijs');
 
 /**
  * @typedef {Object} FetchOptions
- * @property {String} method  The request method.
- * @property {Object} headers The request headers.
- * @property {String} body    The request body.
+ * @property {string}  method  The request method.
+ * @property {Object}  headers The request headers.
+ * @property {string}  body    The request body.
+ * @property {boolean} json    Whether or not the response should _"JSON decoded"_.
  */
 
 /**
@@ -317,11 +318,13 @@ class APIClient {
   }
   /**
    * Makes a request.
-   * @param {Object} options         The request options.
-   * @param {String} options.url     The request URL.
-   * @param {String} options.method  The request method. `GET` by default.
-   * @param {Object} options.body    A request body to send.
-   * @param {Object} options.headers The request headers.
+   * @param {Object}  options         The request options.
+   * @param {string}  options.url     The request URL.
+   * @param {string}  options.method  The request method. `GET` by default.
+   * @param {Object}  options.body    A request body to send.
+   * @param {Object}  options.headers The request headers.
+   * @param {boolean} options.json    Whether or not the response should _"JSON decoded"_. `true`
+   *                                  by default.
    * @return {Promise<Object,Error>}
    * @todo Add support for a `string` `body`.
    */
@@ -336,10 +339,12 @@ class APIClient {
     if (Object.keys(headers).length) {
       opts.headers = headers;
     }
-    // Get the request URL.
+    // Format the flag the method will use to decided whether to decode the response or not.
+    const handleAsJSON = typeof opts.json === 'boolean' ? opts.json : true;
     const { url } = opts;
-    // Remove the URL from the options in order to make it a valid FetchOptions object.
+    // Remove the necessary options in order to make it a valid `FetchOptions` object.
     delete opts.url;
+    delete opts.json;
     // If the options include a body...
     if (opts.body) {
       // Let's first check if there are headers and if a `Content-Type` has been set.
@@ -367,8 +372,13 @@ class APIClient {
     .then((response) => {
       // Capture the response status.
       responseStatus = response.status;
-      // If the response supports `json()`, decode it, otherwise return the same response.
-      return response.json ? response.json() : response;
+      /**
+       * If the response should be handled as JSON and it has a `json()` method, return the
+       * promise of the decoded content, otherwise just return the same object.
+       */
+      return handleAsJSON && response.json ?
+        response.json() :
+        response;
     })
     .then((response) => (
       /**

--- a/tests/shared/apiClient.test.js
+++ b/tests/shared/apiClient.test.js
@@ -272,7 +272,7 @@ describe('APIClient', () => {
     });
   });
 
-  it('should make a successfully GET request with a client that doesn\'t support json()', () => {
+  it('should make a successfully GET request with a response that doesn\'t support json()', () => {
     // Given
     const requestURL = 'http://example.com';
     const requestResponseData = {
@@ -290,6 +290,32 @@ describe('APIClient', () => {
     .then((response) => {
       // Then
       expect(response.data).toEqual(requestResponseData);
+    })
+    .catch((error) => {
+      throw error;
+    });
+  });
+
+  it('should make a successfully GET request without decoding the response', () => {
+    // Given
+    const requestURL = 'http://example.com';
+    const requestResponse = {
+      status: 200,
+      json: jest.fn(),
+    };
+    const fetchClient = jest.fn(() => Promise.resolve(requestResponse));
+    let sut = null;
+    // When
+    sut = new APIClient('', '', fetchClient);
+    return sut.fetch({ url: requestURL, json: false })
+    .then((response) => {
+      // Then
+      expect(response).toEqual(requestResponse);
+      expect(requestResponse.json).toHaveBeenCalledTimes(0);
+      expect(fetchClient).toHaveBeenCalledTimes(1);
+      expect(fetchClient).toHaveBeenCalledWith(requestURL, {
+        method: 'GET',
+      });
     })
     .catch((error) => {
       throw error;
@@ -655,7 +681,7 @@ describe('APIClient', () => {
       throw error;
     });
   });
-  
+
   it('should make a successfully HEAD request using the shortcut method', () => {
     // Given
     const requestURL = 'http://example.com';


### PR DESCRIPTION
### What does this PR do?

Adds a new custom option to the API client requests where you can specify whether the client should call the response `json()` method (when available) or not.

The issue is that if the request doesn't have a response body, even if `json()` is available, calling it will cause an error as there's nothing to decode.

Kudos to @emiprandi for finding the scenario!

### How should it be tested manually?

Make some requests adding `json: false` to the options and make sure you get the stream as response and not the decoded value.

Try a request to an endpoint without response in order to trigger the initial error; then add the `json: false` and see if it gets fixed.

Finally...

```bash
npm test
# or
yarn test
```