### PR TITLE
fix(shared/objectUtils): Don't break on extract and failWithError false by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wootils",
   "description": "A set of Javascript utilities for building Node and browser apps.",
   "homepage": "https://homer0.github.io/wootils/",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "repository": "homer0/wootils",
   "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
   "license": "MIT",

--- a/shared/objectUtils.js
+++ b/shared/objectUtils.js
@@ -55,7 +55,7 @@ class ObjectUtils {
    * @return {*}
    * @throws {Error} If the path is invalid and `failWithError` is set to `true`.
    */
-  static get(target, objPath, pathDelimiter = '.', failWithError = true) {
+  static get(target, objPath, pathDelimiter = '.', failWithError = false) {
     const parts = objPath.split(pathDelimiter);
     const first = parts.shift();
     let currentElement = target[first];
@@ -106,7 +106,7 @@ class ObjectUtils {
     objPath,
     value,
     pathDelimiter = '.',
-    failWithError = true
+    failWithError = false
   ) {
     let result = this.copy(target);
     if (objPath.includes(pathDelimiter)) {
@@ -163,22 +163,22 @@ class ObjectUtils {
    *   'address.planet'
    * ]));
    * // Will output { name: 'Rosario', age: 3, address: { planet: 'earth' } }
-   * @param {Object}               target               The object from where the
+   * @param {Object}              target                The object from where the
    *                                                    property/properties will be extracted.
-   * @param {Array|Object|string}  objPaths             This can be a single path or a list of
+   * @param {Array|Object|string} objPaths              This can be a single path or a list of
    *                                                    them. And for this method, the paths are
    *                                                    not only strings but can also be an object
    *                                                    with a single key, the would be the path
    *                                                    to where to "do the extraction", and the
    *                                                    value the path on the target object.
-   * @param {string}               [pathDelimiter='.']  The delimiter that will separate the
+   * @param {string}              [pathDelimiter='.']   The delimiter that will separate the
    *                                                    path components.
-   * @param {boolean}              [failWithError=true] Whether or not to throw an error when the
+   * @param {boolean}             [failWithError=false] Whether or not to throw an error when the
    *                                                    path is invalid. If this is `false`, the
    *                                                    method will silently fail an empty object.
    * @return {Object}
    */
-  static extract(target, objPaths, pathDelimiter = '.', failWithError = true) {
+  static extract(target, objPaths, pathDelimiter = '.', failWithError = false) {
     const copied = this.copy(target);
     let result = {};
     (Array.isArray(objPaths) ? objPaths : [objPaths])
@@ -242,7 +242,7 @@ class ObjectUtils {
    *                                              property the parent object is empty, it will
    *                                              remove it recursively until a non empty parent
    *                                              object is found.
-   * @param {boolean} [failWithError=true]        Whether or not to throw an error when the path
+   * @param {boolean} [failWithError=false]       Whether or not to throw an error when the path
    *                                              is invalid. If this is `false`, the method will
    *                                              silently fail.
    * @return {Object} A copy of the original object with the removed property/properties.
@@ -252,7 +252,7 @@ class ObjectUtils {
     objPath,
     pathDelimiter = '.',
     cleanEmptyProperties = true,
-    failWithError = true
+    failWithError = false
   ) {
     const parts = objPath.split(pathDelimiter);
     const last = parts.pop();

--- a/shared/objectUtils.js
+++ b/shared/objectUtils.js
@@ -202,15 +202,15 @@ class ObjectUtils {
     .some((pathInfo) => {
       let breakLoop = false;
       const value = this.get(copied, pathInfo.origin, pathDelimiter, failWithError);
-      if (typeof value === 'undefined') {
-        breakLoop = true;
-      } else if (pathInfo.customDest) {
-        result = this.set(result, pathInfo.dest, value, pathDelimiter, failWithError);
-        if (typeof result === 'undefined') {
-          breakLoop = true;
+      if (typeof value !== 'undefined') {
+        if (pathInfo.customDest) {
+          result = this.set(result, pathInfo.dest, value, pathDelimiter, failWithError);
+          if (typeof result === 'undefined') {
+            breakLoop = true;
+          }
+        } else {
+          result[pathInfo.dest] = value;
         }
-      } else {
-        result[pathInfo.dest] = value;
       }
 
       return breakLoop;

--- a/tests/shared/objectUtils.test.js
+++ b/tests/shared/objectUtils.test.js
@@ -113,36 +113,13 @@ describe('ObjectUtils', () => {
       expect(result).toBe(name);
     });
 
-    it('should throw an error when trying to read a property that doesn\'t exist', () => {
-      // Given
-      const target = {};
-      const fakePath = 'something';
-      // When/Then
-      expect(() => ObjectUtils.get(target, fakePath))
-      .toThrow(new RegExp(`there's nothing on '${fakePath}'`, 'i'));
-    });
-
-    it('should throw an error when trying to read a path that doesn\'t exist', () => {
-      // Given
-      const topElement = 'person';
-      const childElement = 'name';
-      const grandChildElement = 'first';
-      const target = {
-        [topElement]: {},
-      };
-      const fakePath = `${topElement}.${childElement}.${grandChildElement}`;
-      // When/Then
-      expect(() => ObjectUtils.get(target, fakePath))
-      .toThrow(new RegExp(`there's nothing on '${topElement}.${childElement}'`, 'i'));
-    });
-
     it('shouldn\'t throw an error when trying to read a property that doesn\'t exist', () => {
       // Given
       const target = {};
       const fakePath = 'something';
       let result = null;
       // When
-      result = ObjectUtils.get(target, fakePath, '.', false);
+      result = ObjectUtils.get(target, fakePath);
       // Then
       expect(result).toBeUndefined();
     });
@@ -160,6 +137,29 @@ describe('ObjectUtils', () => {
       result = ObjectUtils.get(target, fakePath, '.', false);
       // When/Then
       expect(result).toBeUndefined();
+    });
+
+    it('should throw an error when trying to read a property that doesn\'t exist', () => {
+      // Given
+      const target = {};
+      const fakePath = 'something';
+      // When/Then
+      expect(() => ObjectUtils.get(target, fakePath, '.', true))
+      .toThrow(new RegExp(`there's nothing on '${fakePath}'`, 'i'));
+    });
+
+    it('should throw an error when trying to read a path that doesn\'t exist', () => {
+      // Given
+      const topElement = 'person';
+      const childElement = 'name';
+      const grandChildElement = 'first';
+      const target = {
+        [topElement]: {},
+      };
+      const fakePath = `${topElement}.${childElement}.${grandChildElement}`;
+      // When/Then
+      expect(() => ObjectUtils.get(target, fakePath, '.', true))
+      .toThrow(new RegExp(`there's nothing on '${topElement}.${childElement}'`, 'i'));
     });
   });
 
@@ -256,26 +256,6 @@ describe('ObjectUtils', () => {
       expect(target).toEqual(copy);
     });
 
-    it('should throw an error when trying to set a property on an non object path', () => {
-      // Given
-      const topElement = 'people';
-      const childElement = 'name';
-      const grandChildElement = 'first';
-      const value = 'Rosario';
-      const target = {
-        [topElement]: {
-          [childElement]: value,
-        },
-      };
-      const objPath = `${topElement}.${childElement}.${grandChildElement}`;
-      // When/Then
-      expect(() => ObjectUtils.set(target, objPath, value))
-      .toThrow(new RegExp(
-        `There's already an element of type 'string' on '${topElement}.${childElement}'`,
-        'i'
-      ));
-    });
-
     it('shouldn\'t throw an error when trying to set a property on an non object path', () => {
       // Given
       const topElement = 'people';
@@ -290,9 +270,29 @@ describe('ObjectUtils', () => {
       const objPath = `${topElement}.${childElement}.${grandChildElement}`;
       let result = null;
       // When
-      result = ObjectUtils.set(target, objPath, value, '.', false);
+      result = ObjectUtils.set(target, objPath, value);
       // Then
       expect(result).toBeUndefined();
+    });
+
+    it('should throw an error when trying to set a property on an non object path', () => {
+      // Given
+      const topElement = 'people';
+      const childElement = 'name';
+      const grandChildElement = 'first';
+      const value = 'Rosario';
+      const target = {
+        [topElement]: {
+          [childElement]: value,
+        },
+      };
+      const objPath = `${topElement}.${childElement}.${grandChildElement}`;
+      // When/Then
+      expect(() => ObjectUtils.set(target, objPath, value, '.', true))
+      .toThrow(new RegExp(
+        `There's already an element of type 'string' on '${topElement}.${childElement}'`,
+        'i'
+      ));
     });
   });
 
@@ -374,50 +374,27 @@ describe('ObjectUtils', () => {
       });
     });
 
-    it('should throw an error when trying to exact from an invalid path', () => {
-      // Given
-      const topElement = 'person';
-      const target = {};
-      // When/Then
-      expect(() => ObjectUtils.extract(target, topElement))
-      .toThrow(new RegExp(`There's nothing on '${topElement}'`, 'i'));
-    });
-
-    it('shouldn\'t throw an error when trying to exact from an invalid path', () => {
+    it('shouldn\'t throw an error when trying to extract from an invalid path', () => {
       // Given
       const topElement = 'person';
       const target = {};
       let result = null;
       // When
-      result = ObjectUtils.extract(target, topElement, '.', false);
+      result = ObjectUtils.extract(target, topElement);
       // Then
       expect(result).toEqual({});
     });
 
-    it('should throw an error when trying to exact reusing a path', () => {
+    it('should throw an error when trying to extract from an invalid path', () => {
       // Given
       const topElement = 'person';
-      const childElement = 'name';
-      const childElementValue = 'Rosario';
-      const target = {
-        [topElement]: {
-          [childElement]: childElementValue,
-          age: 3,
-          planet: 'earth',
-        },
-      };
+      const target = {};
       // When/Then
-      expect(() => ObjectUtils.extract(target, [
-        { [topElement]: `${topElement}.${childElement}` },
-        { [`${topElement}.${childElement}`]: `${topElement}.${childElement}` },
-      ]))
-      .toThrow(new RegExp(
-        `There's already an element of type 'string' on '${topElement}'`,
-        'i'
-      ));
+      expect(() => ObjectUtils.extract(target, topElement, '.', true))
+      .toThrow(new RegExp(`There's nothing on '${topElement}'`, 'i'));
     });
 
-    it('shouldn\'t throw an error when trying to exact reusing a path', () => {
+    it('shouldn\'t throw an error when trying to extract reusing a path', () => {
       // Given
       const topElement = 'person';
       const childElement = 'name';
@@ -436,12 +413,38 @@ describe('ObjectUtils', () => {
         [
           { [topElement]: `${topElement}.${childElement}` },
           { [`${topElement}.${childElement}`]: `${topElement}.${childElement}` },
-        ],
-        '.',
-        false
+        ]
       );
       // Then
       expect(result).toBeUndefined();
+    });
+
+    it('should throw an error when trying to extract reusing a path', () => {
+      // Given
+      const topElement = 'person';
+      const childElement = 'name';
+      const childElementValue = 'Rosario';
+      const target = {
+        [topElement]: {
+          [childElement]: childElementValue,
+          age: 3,
+          planet: 'earth',
+        },
+      };
+      // When/Then
+      expect(() => ObjectUtils.extract(
+        target,
+        [
+          { [topElement]: `${topElement}.${childElement}` },
+          { [`${topElement}.${childElement}`]: `${topElement}.${childElement}` },
+        ],
+        '.',
+        true
+      ))
+      .toThrow(new RegExp(
+        `There's already an element of type 'string' on '${topElement}'`,
+        'i'
+      ));
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

After publishing it, I thought that the real cases in which you would use `get` or `extract` are those where you want to avoid multiple `if`s to check if part of the path is there or not, so it didn't make sense to have `failWithError` set to `true` as it would throw an exception and possibly stop your code execution, that's why I made it `false` by default.

Also, based on the what I said above about real cases, when the `extract` method was unable to find one of the paths (and `failWithError` was `false`), it wouldn't throw an error, but it would just return an empty object.... why? it should return at least the properties it found! Well, it does that now.

Ok, this should be a breaking change, but I released this an hour ago, so I doubt anyone already implemented it, so... I'll handle it as a hotfix.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
