### PR TITLE
v2.2.2: fix(browser/simpleStorage): Fix typos and the way arrays are being copied

### DIFF
--- a/browser/simpleStorage.js
+++ b/browser/simpleStorage.js
@@ -562,12 +562,19 @@ class SimpleStorage {
   }
   /**
    * Makes a deep copy of an object.
-   * @param {Object} obj The object to copy.
-   * @return {Object}
+   * @param {Object|Array} obj The object to copy.
+   * @return {Object|Array}
    * @access protected
    */
   _copy(obj) {
-    return extend(true, {}, obj);
+    let result;
+    if (Array.isArray(obj)) {
+      ({ obj: result } = extend(true, {}, { obj }));
+    } else {
+      result = extend(true, {}, obj);
+    }
+
+    return result;
   }
   /**
    * Helper method to get the current timestamp in seconds.

--- a/browser/simpleStorage.js
+++ b/browser/simpleStorage.js
@@ -315,7 +315,7 @@ class SimpleStorage {
    * @access protected
    */
   _getEntryValue(key) {
-    const entry = this.getEntry(key);
+    const entry = this._getEntry(key);
     return entry ? entry.value : entry;
   }
   /**
@@ -397,9 +397,9 @@ class SimpleStorage {
   _delete(reset = true) {
     delete this._storage.delete(this._options.storage.key);
     if (reset) {
-      this.setData(this._getInitialData(), false);
+      this._setData(this._getInitialData(), false);
     } else {
-      this.setData({}, false);
+      this._setData({}, false);
     }
   }
   /**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wootils",
   "description": "A set of Javascript utilities for building Node and browser apps.",
   "homepage": "https://homer0.github.io/wootils/",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "repository": "homer0/wootils",
   "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
   "license": "MIT",

--- a/tests/browser/simpleStorage.test.js
+++ b/tests/browser/simpleStorage.test.js
@@ -755,6 +755,57 @@ describe('SimpleStorage', () => {
       );
     });
 
+    it('should add and save a new array entry', () => {
+      // Given
+      const currentTime = 0;
+      global.Date = {
+        now: jest.fn(() => currentTime),
+      };
+      const storageKey = 'myStorage';
+      const entryKey = 'user';
+      const entryValue = ['Rosario', 'Charo', 'Charito'];
+      const mStorage = getStorageProxy();
+      const mWindow = {
+        localStorage: mStorage,
+      };
+      const options = {
+        window: mWindow,
+        storage: {
+          key: storageKey,
+        },
+        entries: {
+          enabled: true,
+          deleteExpired: false,
+        },
+      };
+      let sut = null;
+      let resultBeforeAdding = null;
+      let resultFromAdding = null;
+      let resultAfterAdding = null;
+      // When
+      sut = getSutProxy(options);
+      resultBeforeAdding = sut.getEntryValue(entryKey);
+      resultFromAdding = sut.addEntry(entryKey, entryValue);
+      resultAfterAdding = sut.getEntryValue(entryKey);
+      // Then
+      expect(resultBeforeAdding).toBeNull();
+      expect(resultFromAdding).toEqual(entryValue);
+      expect(resultAfterAdding).toEqual(entryValue);
+      expect(mStorage.mocks.get).toHaveBeenCalledTimes(1);
+      expect(mStorage.mocks.get).toHaveBeenCalledWith(options.storage.key);
+      expect(mStorage.mocks.set).toHaveBeenCalledTimes(2);
+      expect(mStorage.mocks.set).toHaveBeenCalledWith(options.storage.key, '{}');
+      expect(mStorage.mocks.set).toHaveBeenCalledWith(
+        options.storage.key,
+        JSON.stringify({
+          [entryKey]: {
+            time: currentTime,
+            value: entryValue,
+          },
+        })
+      );
+    });
+
     it('should add a new entry but not save it', () => {
       // Given
       const currentTime = 0;


### PR DESCRIPTION
### What does this PR do?

There were two bugs in the `simpleStorage` class:

First, there were some internal calls to methods with the wrong name (without the underscore in front). I didn't catch this before because the proxy I'm using to test the class :/.

The other bug was that if you were to send an array as the value of an entry, when the object was being copied, the class was transforming it into an object. This was because I was using `extend` directly instead of checking if the object was an array.

### How should it be tested manually?

Try saving an entry, that should be enough to clear the two bugs, and...

```bash
yarn test
# or
npm test
```
