### PR TITLE
Don't force Yarn on the hooks

### DIFF
--- a/utils/hooks/post-merge.local
+++ b/utils/hooks/post-merge.local
@@ -1,3 +1,7 @@
 #!/bin/bash -ex
 
-yarn
+if hash yarn 2>/dev/null; then
+  yarn
+else
+  npm install
+fi

--- a/utils/hooks/pre-commit.local
+++ b/utils/hooks/pre-commit.local
@@ -1,4 +1,9 @@
 #!/bin/bash -e
 
-yarn run lint
-yarn test
+if hash yarn 2>/dev/null; then
+  yarn run lint
+  yarn test
+else
+  npm run lint
+  npm test
+fi


### PR DESCRIPTION
### What does this PR do?

I like using Yarn for my projects, but I thought that it wasn't cool that I was forcing anyone cloning the repo to either use it or get used to seeing errors from the repository hooks, where the commands are hardcoded with Yarn.

So, in this PR I'm updating the hooks so they'll only use Yarn  only if it's available, otherwise, they'll use NPM.

> Yes, on Windows you are forced to used Yarn, but there's a reason for that... #32 

### How should it be tested manually?

Try running the repository hooks on an environment without Yarn.

> I didn't modify anything from the source code, so there's no reason to run the tests :P.