### PR TITLE
v2.4.0: feat(node/appConfiguration): allow paths for get and set

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wootils",
   "description": "A set of Javascript utilities for building Node and browser apps.",
   "homepage": "https://homer0.github.io/wootils/",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "repository": "homer0/wootils",
   "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "fs-extra": "8.0.1",
     "colors": "1.3.3",
     "urijs": "1.19.1",
-    "statuses": "1.5.0"
+    "statuses": "1.5.0",
+    "extend": "^3.0.2"
   },
   "devDependencies": {
     "eslint": "5.16.0",

--- a/tests/node/appConfiguration.test.js
+++ b/tests/node/appConfiguration.test.js
@@ -1,3 +1,4 @@
+jest.unmock('/shared/objectUtils');
 jest.unmock('/node/appConfiguration');
 jest.mock('jimple', () => ({ provider: jest.fn(() => 'provider') }));
 
@@ -335,6 +336,52 @@ describe('AppConfiguration', () => {
     expect(result).toEqual({});
   });
 
+  it('should merge an entire configuration by its name', () => {
+    // Given
+    const environmentUtils = 'environmentUtils';
+    const rootRequire = 'rootRequire';
+    const newConfigName = 'charitoConfig';
+    const newConfigSettings = {
+      name: 'charito',
+      allowConfigurationSwitch: true,
+    };
+    const updatedSettings = {
+      allowConfigurationSwitch: false,
+      extra: 'value',
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new AppConfiguration(environmentUtils, rootRequire);
+    sut.load(newConfigName, newConfigSettings);
+    result = sut.setConfig(updatedSettings, newConfigName);
+    // Then
+    expect(result).toEqual(Object.assign({}, newConfigSettings, updatedSettings));
+  });
+
+  it('should overwrite an entire configuration by its name', () => {
+    // Given
+    const environmentUtils = 'environmentUtils';
+    const rootRequire = 'rootRequire';
+    const newConfigName = 'charitoConfig';
+    const newConfigSettings = {
+      name: 'charito',
+      allowConfigurationSwitch: true,
+    };
+    const updatedSettings = {
+      allowConfigurationSwitch: false,
+      extra: 'value',
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new AppConfiguration(environmentUtils, rootRequire);
+    sut.load(newConfigName, newConfigSettings);
+    result = sut.setConfig(updatedSettings, newConfigName, false);
+    // Then
+    expect(result).toEqual(updatedSettings);
+  });
+
   it('should return a setting of the active configuration by its name', () => {
     // Given
     const environmentUtils = 'environmentUtils';
@@ -354,6 +401,30 @@ describe('AppConfiguration', () => {
     result = sut.get(newSettingName);
     // Then
     expect(result).toEqual(newSettingValue);
+  });
+
+  it('should return a setting of the active configuration by its path', () => {
+    // Given
+    const environmentUtils = 'environmentUtils';
+    const rootRequire = 'rootRequire';
+    const newSettingName = 'version';
+    const newSubSettingName = 'type';
+    const newSubSettingValue = 'alpha';
+    const newConfigName = 'charitoConfig';
+    const newConfigSettings = {
+      name: 'charito',
+      [newSettingName]: {
+        [newSubSettingName]: newSubSettingValue,
+      },
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new AppConfiguration(environmentUtils, rootRequire);
+    sut.load(newConfigName, newConfigSettings);
+    result = sut.get(`${newSettingName}.${newSubSettingName}`);
+    // Then
+    expect(result).toEqual(newSubSettingValue);
   });
 
   it('should return the active configuration name when trying to get the `name` setting', () => {
@@ -400,6 +471,76 @@ describe('AppConfiguration', () => {
     result = sut.get([newSettingOneName, newSettingTwoName]);
     // Then
     expect(result).toEqual(expectedSettings);
+  });
+
+  it('should return the settings from the active configuration by their path', () => {
+    // Given
+    const environmentUtils = 'environmentUtils';
+    const rootRequire = 'rootRequire';
+    const newSettingOneName = 'version';
+    const newSubSettingOneName = 'type';
+    const newSubSettingOneValue = 'alpha';
+    const newSettingTwoName = 'date';
+    const newSubSettingTwoName = 'date';
+    const newSubSettingTwoValue = '25';
+    const newConfigName = 'charitoConfig';
+    const newConfigSettings = {
+      name: 'charito',
+      [newSettingOneName]: {
+        [newSubSettingOneName]: newSubSettingOneValue,
+      },
+      [newSettingTwoName]: {
+        [newSubSettingTwoName]: newSubSettingTwoValue,
+      },
+    };
+    const pathOne = `${newSettingOneName}.${newSubSettingOneName}`;
+    const pathTwo = `${newSettingTwoName}.${newSubSettingTwoName}`;
+    let sut = null;
+    let result = null;
+    // When
+    sut = new AppConfiguration(environmentUtils, rootRequire);
+    sut.load(newConfigName, newConfigSettings);
+    result = sut.get([pathOne, pathTwo]);
+    // Then
+    expect(result).toEqual({
+      [pathOne]: newSubSettingOneValue,
+      [pathTwo]: newSubSettingTwoValue,
+    });
+  });
+
+  it('should return a list of settings from the active configuration by their path', () => {
+    // Given
+    const environmentUtils = 'environmentUtils';
+    const rootRequire = 'rootRequire';
+    const newSettingOneName = 'version';
+    const newSubSettingOneName = 'type';
+    const newSubSettingOneValue = 'alpha';
+    const newSettingTwoName = 'date';
+    const newSubSettingTwoName = 'date';
+    const newSubSettingTwoValue = '25';
+    const newConfigName = 'charitoConfig';
+    const newConfigSettings = {
+      name: 'charito',
+      [newSettingOneName]: {
+        [newSubSettingOneName]: newSubSettingOneValue,
+      },
+      [newSettingTwoName]: {
+        [newSubSettingTwoName]: newSubSettingTwoValue,
+      },
+    };
+    const pathOne = `${newSettingOneName}.${newSubSettingOneName}`;
+    const pathTwo = `${newSettingTwoName}.${newSubSettingTwoName}`;
+    let sut = null;
+    let result = null;
+    // When
+    sut = new AppConfiguration(environmentUtils, rootRequire);
+    sut.load(newConfigName, newConfigSettings);
+    result = sut.get([pathOne, pathTwo], true);
+    // Then
+    expect(result).toEqual([
+      newSubSettingOneValue,
+      newSubSettingTwoValue,
+    ]);
   });
 
   it('should set the value of a setting from the active configuration', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2357,7 +2357,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.2:
+extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==


### PR DESCRIPTION
### What does this PR do?

Mainly, the objective of the PR is to replace `extend` with `ObjectUtils` on the `AppConfiguration` class, and by doing that, we get paths support by free.

```js
// You do this now:
appConfiguration.get('api.endpoints.something');
// instead of
appConfiguration.get('api').endpoints.something;
```

And it also works for `set`:

```js
appConfiguration.set('api.settings.baseUrl', 'http://....');
```

Now, given this new feature, when you do multiple _"gets"_ at once, the returned object would be paths, so it wouldn't be easy to destruct:

```js
const settings = appConfiguration.get([
  'api.settings.url',
  'api.settings.endpoints']
);
// {
//   'api.settings.url': ...,
//   'api.settings.endpoint': ...,
// }
```

So, for now, I added a second parameter to get: `asArray = false`. If you set it to `true`, when asking for multiple paths, you'll get an array instead of an object:

```js
const [url, endpoints] = appConfiguration.get([
  'api.settings.url',
  'api.settings.endpoints']
);
```

**On the next breaking release, it will probably be changed to the default behavior**

### How should it be tested manually?

This shouldn't be breaking, so try running any existing app; and of course...

```bash
yarn test
# or
npm test
```