### PR TITLE
feat(node/environmentUtils): add way to make a required .get and add a method for .set

### DIFF
--- a/documents/node/environmentUtils.md
+++ b/documents/node/environmentUtils.md
@@ -1,10 +1,12 @@
 # EnvironmentUtils
 
-A really small service to centralize the place where you read environment variables and check if you are running on development or production.
+A really small service to centralize the place where you read and write environment variables, and check if you are running on development or production.
 
-Is not uncommon nowadays for Node apps to be checking `NODE_ENV` and other environment variables in order to do or not to do some stuff, and having multiple calls to `process.env` on different places of your app may not be a good idea: It's hard to track and maintain.
+Is not uncommon nowadays for Node apps to be checking `NODE_ENV` and other environment variables in order to do or not to do certain things, and having multiple calls to `process.env` on different places of your app may not be a good idea: It's hard to track and maintain.
 
-## Example
+## Examples
+
+### Read
 
 Let's say your code looks something like this:
 
@@ -18,7 +20,7 @@ console.log(`Hello ${process.env.NAME}`);
 
 Let's implement the same but with `EnvironmentUtils`:
 
-### Without Jimple
+#### Without Jimple
 
 > If you haven't tried [Jimple](https://github.com/fjorgemota/jimple), give it a try, it's excellent for organizing your app dependencies and services.
 
@@ -33,7 +35,7 @@ const environmentUtils = new EnvironmentUtils();
 Now, to update the code:
 
 ```js
-if (environmentUtils.development()) {
+if (environmentUtils.development) {
   addSomeStuffForDevelopment();
 }
 // The service allows you to set a default in case the variable is not defined.
@@ -43,7 +45,7 @@ console.log(`Hello ${name}`);
 
 Done! Now you are not manually checking for `NODE_ENV` and all your variables are being read on a single place.
 
-### With Jimple
+#### With Jimple
 
 Let's setup a dummy app and register the service:
 
@@ -71,13 +73,79 @@ console.log(`Hello ${name}`);
 
 Done! Now you are not manually checking for `NODE_ENV` and all your variables are being read on a single place.
 
+### Write
+
+Ok, writing on the environment from inside an application is not that common as reading, but there are certain cases where this may come in handy.
+
+Let's say you are using a library that has a _"debug mode"_ but the only way to enable it is using a environment variable, and for "purposes of debugging", you want to do it from your code:
+
+```js
+process.env.DEBUG_MY_LIBRARY = 'true';
+runMyMagicLibrary();
+```
+
+Like for `get`, `set` also allows you to centralize where you overwrite your environment variables, but at the same time, it protects you from overwriting something that is already declared: Unless you tell `set` to overwrite declarations, if the variable already exists, it won't do it.
+
+#### Without Jimple
+
+Let's start with the setup:
+
+```js
+const { EnvironmentUtils } = require('wootils/node');
+// Construct an instance.
+const environmentUtils = new EnvironmentUtils();
+```
+
+Now, to update the code:
+
+```js
+// If you add a third parameter with `true`, it will overwrite any previous declaration.
+const name = environmentUtils.set('DEBUG_MY_LIBRARY', 'true');
+runMyMagicLibrary();
+```
+
+Done! Now you are not manually updating the environment variable and potentially overwriting something that was already declared.
+
+#### With Jimple
+
+Let's setup a dummy app and register the service:
+
+```js
+// Import all the required modules
+const Jimple = require('jimple');
+const { environmentUtils } = require('wootils/node/providers');
+// Create a dummy app
+const app = new Jimple();
+
+app.register(environmentUtils);
+```
+Now, to update the code:
+ 
+```js
+// The imported provider has the same name, that's why I called it `envUtils`.
+const envUtils = app.get('environmentUtils');
+// If you add a third parameter with `true`, it will overwrite any previous declaration.
+const name = envUtils.set('DEBUG_MY_LIBRARY', 'true');
+runMyMagicLibrary();
+```
+
+Done! Now you are not manually updating the environment variable and potentially overwriting something that was already declared.
+
 ## Features
 
 ### Reading variables
 
-This was demonstrated on the example above. You just need to `.get()` with the name of the variable you want to read.
+This was demonstrated on the first example. You just need to `.get()` with the name of the variable you want to read.
 
-### Checking the environment
+### Writing variables
+
+This was demostrated on the second example. You just need to `.set()` with the name and the value for the variable.
+
+### Validating variables
+
+You can call `.exists()` with the name of the variable and the service will tell you if it's defined on the environment.
+
+### Environment type validation
 
 No more `if (process.env.NODE_ENV ...`, `EnvironmentUtils` does it once when you instantiate it and then gives you `production()` and `development()` for you to use.
 

--- a/node/environmentUtils.js
+++ b/node/environmentUtils.js
@@ -20,15 +20,21 @@ class EnvironmentUtils {
   }
   /**
    * Get the value of an environment variable.
-   * @param {string} name              The name of the variable.
-   * @param {string} [defaultValue=''] A fallback value in case the variable is `undefined`
+   * @param {string}  name              The name of the variable.
+   * @param {string}  [defaultValue=''] A fallback value in case the variable is `undefined`
+   * @param {boolean} [required=false]  If the variable is required and `undefined`, it will throw
+   *                                    an error.
    * @return {string}
-   * @todo add a `require` parameter to throw an error if the variable is not preset.
+   * @throws {Error} if `required` is set to `true` and the variable is `undefined`.
    */
-  get(name, defaultValue = '') {
+  get(name, defaultValue = '', required = false) {
     // eslint-disable-next-line no-process-env
     let value = process.env[name];
     if (typeof value === 'undefined') {
+      if (required) {
+        throw new Error(`The following environment variable is missing: ${name}`);
+      }
+
       value = defaultValue;
     }
 

--- a/node/environmentUtils.js
+++ b/node/environmentUtils.js
@@ -19,7 +19,7 @@ class EnvironmentUtils {
     this.production = this.env === 'production';
   }
   /**
-   * Get the value of an environment variable.
+   * Gets the value of an environment variable.
    * @param {string}  name              The name of the variable.
    * @param {string}  [defaultValue=''] A fallback value in case the variable is `undefined`
    * @param {boolean} [required=false]  If the variable is required and `undefined`, it will throw
@@ -28,9 +28,10 @@ class EnvironmentUtils {
    * @throws {Error} if `required` is set to `true` and the variable is `undefined`.
    */
   get(name, defaultValue = '', required = false) {
-    // eslint-disable-next-line no-process-env
-    let value = process.env[name];
-    if (typeof value === 'undefined') {
+    let value;
+    if (this.exists(name)) {
+      value = process.env[name];
+    } else {
       if (required) {
         throw new Error(`The following environment variable is missing: ${name}`);
       }
@@ -39,6 +40,33 @@ class EnvironmentUtils {
     }
 
     return value;
+  }
+  /**
+   * Sets the value of an environment variable.
+   * @param {string} name              The name of the variable
+   * @param {string} value             The value of the variable.
+   * @param {string} [overwrite=false] If the variable already exists, the method won't overwrite
+   *                                   it, unless you set this parameter to `true`.
+   * @return {boolean} Whether or not the variable was set.
+   */
+  set(name, value, overwrite = false) {
+    let result;
+    if (!this.exists(name) || overwrite) {
+      process.env[name] = value;
+      result = true;
+    } else {
+      result = false;
+    }
+
+    return result;
+  }
+  /**
+   * Checks whether an environment variable exists or not.
+   * @param {string} name The name of the variable.
+   * @return {boolean}
+   */
+  exists(name) {
+    return typeof process.env[name] !== 'undefined';
   }
   /**
    * Check whether or not the environment is for development.

--- a/tests/node/environmentUtils.test.js
+++ b/tests/node/environmentUtils.test.js
@@ -70,6 +70,56 @@ describe('EnvironmentUtils', () => {
     .toThrow(/The following environment variable is missing/i);
   });
 
+  it('should set the value for an environment variable', () => {
+    // Given
+    const varName = 'BATMAN_IDENTITY';
+    const varValue = 'Bruce Wayne';
+    let result = null;
+    let saved = null;
+    // When
+    delete process.env[varName];
+    const envUtils = new EnvironmentUtils();
+    result = envUtils.set(varName, varValue);
+    saved = envUtils.get(varName);
+    // Then
+    expect(result).toBeTrue();
+    expect(saved).toBe(varValue);
+  });
+
+  it('shouldn\'t overwrite an existing environment variable', () => {
+    // Given
+    const varName = 'ROBIN_IDENTITY';
+    const varOriginalValue = 'Tim Drake';
+    const varValue = 'Damian Wayne';
+    let result = null;
+    let saved = null;
+    // When
+    process.env[varName] = varOriginalValue;
+    const envUtils = new EnvironmentUtils();
+    result = envUtils.set(varName, varValue);
+    saved = envUtils.get(varName);
+    // Then
+    expect(result).toBeFalse();
+    expect(saved).toBe(varOriginalValue);
+  });
+
+  it('should overwrite an existing environment variable', () => {
+    // Given
+    const varName = 'ROBIN_IDENTITY';
+    const varOriginalValue = 'Tim Drake';
+    const varValue = 'Damian Wayne';
+    let result = null;
+    let saved = null;
+    // When
+    process.env[varName] = varOriginalValue;
+    const envUtils = new EnvironmentUtils();
+    result = envUtils.set(varName, varValue, true);
+    saved = envUtils.get(varName);
+    // Then
+    expect(result).toBeTrue();
+    expect(saved).toBe(varValue);
+  });
+
   it('should have a Jimple provider to register the service', () => {
     // Given
     const container = {

--- a/tests/node/environmentUtils.test.js
+++ b/tests/node/environmentUtils.test.js
@@ -53,7 +53,7 @@ describe('EnvironmentUtils', () => {
     expect(result).toBe(varValue);
   });
 
-  it('should fallback to an empty string if a required variable doesn\'t exist', () => {
+  it('should fallback to an empty string if a specified variable doesn\'t exist', () => {
     // Given
     let result = 'unknown';
     // When
@@ -61,6 +61,13 @@ describe('EnvironmentUtils', () => {
     result = envUtils.get('Charito');
     // Then
     expect(result).toBeEmptyString();
+  });
+
+  it('should throw an error if a required variable doesn\'t exist', () => {
+    // Given/When/Then
+    const envUtils = new EnvironmentUtils();
+    expect(() => envUtils.get('Charito', '', true))
+    .toThrow(/The following environment variable is missing/i);
   });
 
   it('should have a Jimple provider to register the service', () => {


### PR DESCRIPTION
### What does this PR do?

#### Add way to make a required `.get`

The method `.get` now has a new third parameter: `[required=false]`. If you set it to `true` and the variable doesn't exist, instead of using the fallback value, it will throw an error.

#### Add a method for `.set`

You can now write environment variables using this class/service:

```js
set(name, value, overwrite = false)
```

The signature is easy to read: the name of the variable and its value; the third parameter exists because, by default, the method won't overwrite an already declared variable, you have to set `overwrite` to `true` in order to force it.

#### New method: `.exists`

When I added `.set` I needed to check if a variable was declared, and since `.get` was already doing the same, I extracted the functionality into a new method:

```js
exists(name)
```

It will return a `boolean` value, telling you whether the variable exists on the environment or not.

### How should it be tested manually?

This is not breaking, so you code should keep working as always; then you can test it by checking for the existence of a variable or defining a custom one.

And of course...

```bash
npm test
# or
yarn test
```
