### PR TITLE
v2.6.1: fix(shared/objectUtils): check for null and undefined on formatKeys

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wootils",
   "description": "A set of Javascript utilities for building Node and browser apps.",
   "homepage": "https://homer0.github.io/wootils/",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "repository": "homer0/wootils",
   "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
   "license": "MIT",

--- a/shared/objectUtils.js
+++ b/shared/objectUtils.js
@@ -416,7 +416,9 @@ class ObjectUtils {
     keys.forEach((key) => {
       const value = target[key];
       hasChildrenByKey[key] = !!(
+        value &&
         typeof value === 'object' &&
+        value !== null &&
         !Array.isArray(value) &&
         Object.keys(value)
       );

--- a/tests/shared/objectUtils.test.js
+++ b/tests/shared/objectUtils.test.js
@@ -771,6 +771,37 @@ describe('ObjectUtils', () => {
       });
     });
 
+    it('should make all keys first letters into upper case (null and undefined)', () => {
+      // Given
+      const name = 'Rosario';
+      const nickname = 'Charito';
+      const age = 3;
+      const likes = null;
+      const hates = undefined;
+      const target = {
+        name,
+        nickname,
+        age,
+        likes,
+        hates,
+      };
+      let result = null;
+      // When
+      result = ObjectUtils.formatKeys(
+        target,
+        /^\w/,
+        (letter) => letter.toUpperCase()
+      );
+      // Then
+      expect(result).toEqual({
+        Name: name,
+        Nickname: nickname,
+        Age: age,
+        Likes: likes,
+        Hates: hates,
+      });
+    });
+
     it('should make specific keys first letters into upper case', () => {
       // Given
       const first = 'Rosario';


### PR DESCRIPTION
### What does this PR do?

This is a follow up for #44 . As pointed out by @ezequielgarcia88, if you were to have properties with `null` or `undefined` values, `ObjectUtils.formatKeys` would break with:

```js
ERROR: Cannot convert undefined or null to object
```

This PR adds an extra check (and a test for it) so it won't try to handle `null` (nor `undefined`) as "object values" and just keep them as they are.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```

### Are there any related PRs?

### TODOs
