### PR TITLE
v2.6.1: fix(shared/apiClient): avoid encoding non-object literals

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wootils",
   "description": "A set of Javascript utilities for building Node and browser apps.",
   "homepage": "https://homer0.github.io/wootils/",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "repository": "homer0/wootils",
   "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
   "license": "MIT",

--- a/shared/apiClient.js
+++ b/shared/apiClient.js
@@ -311,9 +311,12 @@ class APIClient {
       }
       // If the body is an object...
       if (typeof opts.body === 'object') {
-        // ...encode it.
-        opts.body = JSON.stringify(opts.body);
-        // And if no `Content-Type` was defined, let's assume is a JSON request.
+        // ...and if it's an object literal...
+        if (Object.getPrototypeOf(opts.body).constructor.name === 'Object') {
+          // ...encode it.
+          opts.body = JSON.stringify(opts.body);
+        }
+        // If no `Content-Type` was defined, let's assume is a JSON request.
         if (!hasContentType) {
           opts.headers['Content-Type'] = 'application/json';
         }

--- a/tests/shared/apiClient.test.js
+++ b/tests/shared/apiClient.test.js
@@ -594,6 +594,40 @@ describe('APIClient', () => {
     });
   });
 
+  it('shouldn\'t encode the body if is not an object literal', () => {
+    // Given
+    const requestURL = 'http://example.com';
+    const requestMethod = 'post';
+    class CustomFormData {}
+    const requestBody = new CustomFormData();
+    const requestResponseData = {
+      message: 'hello-world',
+    };
+    const requestResponse = {
+      status: 200,
+      json: jest.fn(() => Promise.resolve(requestResponseData)),
+    };
+    const fetchClient = jest.fn(() => Promise.resolve(requestResponse));
+    const headers = {
+      'Content-Type': 'application/custom-form-data',
+    };
+    let sut = null;
+    // When
+    sut = new APIClient('', '', fetchClient);
+    return sut.post(requestURL, requestBody, { headers })
+    .then((response) => {
+      // Then
+      expect(response).toEqual(requestResponseData);
+      expect(requestResponse.json).toHaveBeenCalledTimes(1);
+      expect(fetchClient).toHaveBeenCalledTimes(1);
+      expect(fetchClient).toHaveBeenCalledWith(requestURL, {
+        headers,
+        method: requestMethod.toUpperCase(),
+        body: requestBody,
+      });
+    });
+  });
+
   it('should make a successfully PUT request using the shortcut method', () => {
     // Given
     const requestURL = 'http://example.com';


### PR DESCRIPTION
### What does this PR do?

This is a fix for #45.

The problem is was that id `apiClient` detected that a request body type was `object`, it would automatically encode it with `JSON.stringify`... but if the body was something like `FormData`, that also returns `object` when validated with `typeof`, it would also encode it.

The proposed solution from @emilianofunk was to check if the header included `json` before doing the encoding, which makes sense and it would be a valid fix, but... it would be a breaking change.

If for some _weird_ reason you were using a custom `content-type` header and assuming the request body was going to be encoded, validating the word `json` on the header would break your implementation.

> Yes, SUPER weird case, but it would be breaking nonetheless.

The way I ended up solving it was to only encode object literals, which makes sense and can be handled as a fix:

```js
if (Object.getPrototypeOf(opts.body).constructor.name === 'Object') {
  ...
}
```

### How should it be tested manually?

Try to make a request using `FormData`, and (because I added an extra case)...

```bash
yarn test
# or
npm test
```