### PR TITLE
v2.6.3: fix(shared/apiClient): avoid calling .json() on empty responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wootils",
   "description": "A set of Javascript utilities for building Node and browser apps.",
   "homepage": "https://homer0.github.io/wootils/",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "repository": "homer0/wootils",
   "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
   "license": "MIT",

--- a/shared/apiClient.js
+++ b/shared/apiClient.js
@@ -329,13 +329,24 @@ class APIClient {
     .then((response) => {
       // Capture the response status.
       responseStatus = response.status;
-      /**
-       * If the response should be handled as JSON and it has a `json()` method, return the
-       * promise of the decoded content, otherwise just return the same object.
-       */
-      return handleAsJSON && response.json ?
-        response.json() :
-        response;
+      let nextStep;
+      // If the response should be handled as JSON and it has a `json()` method...
+      if (handleAsJSON && typeof response.json === 'function') {
+        /**
+         * Make sure there's a response to be parsed, otherwise just set to return an empty
+         * object.
+         */
+        if (typeof response.size === 'undefined' || response.size > 0) {
+          nextStep = response.json();
+        } else {
+          nextStep = {};
+        }
+      } else {
+        // If the response shouldn't be handled as JSON, set to return the raw object.
+        nextStep = response;
+      }
+
+      return nextStep;
     })
     .then((response) => (
       /**

--- a/tests/shared/apiClient.test.js
+++ b/tests/shared/apiClient.test.js
@@ -342,6 +342,30 @@ describe('APIClient', () => {
     });
   });
 
+  it('should make a successfully GET request without decoding an empty response', () => {
+    // Given
+    const requestURL = 'http://example.com';
+    const requestResponse = {
+      status: 200,
+      size: 0,
+      json: jest.fn(),
+    };
+    const fetchClient = jest.fn(() => Promise.resolve(requestResponse));
+    let sut = null;
+    // When
+    sut = new APIClient('', '', fetchClient);
+    return sut.fetch({ url: requestURL })
+    .then((response) => {
+      // Then
+      expect(response).toEqual({});
+      expect(requestResponse.json).toHaveBeenCalledTimes(0);
+      expect(fetchClient).toHaveBeenCalledTimes(1);
+      expect(fetchClient).toHaveBeenCalledWith(requestURL, {
+        method: 'GET',
+      });
+    });
+  });
+
   it('should make a successfully POST request', () => {
     // Given
     const requestURL = 'http://example.com';


### PR DESCRIPTION
### What does this PR do?

The bug: If a request response were to be handled as a `JSON`, but the actual response was empty (`201` for example), calling `.json()` would throw `Unexpected end of JSON input`.

The fix: If a request response is going to be handled as a `JSON` and the response `size` property is `undefined` or it's greater than `0`, **then** call `.json()`; otherwise, just return an empty object.

### How should it be tested manually?

You first need an API/url of something that would return a `200`/`201` response without a body.

Then, try making a request using the `master` branch, it should throw the error.

Move to this branch and test it again, you should get an empty object.

Also, don't forget to...

```bash
yarn test
# or
npm test
```
