### PR TITLE
refactor: take care of a couple of to-do's

### DIFF
--- a/node/logger.js
+++ b/node/logger.js
@@ -47,6 +47,13 @@ class Logger {
      * @type {boolean}
      */
     this.showTime = showTime;
+    /**
+     * An alias for the {@link Logger#warning} method.
+     *
+     * @type {Function}
+     * @see {@link Logger#warning}
+     */
+    this.warn = this.warning.bind(this);
   }
   /**
    * Logs an error (red) message or messages on the console.
@@ -172,7 +179,6 @@ class Logger {
    *
    * @param {LoggerMessage} message A single message of a list of them.
    * @see {@link Logger#log}
-   * @todo Add `warn` alias.
    */
   warning(message) {
     this.log(message, 'yellow');

--- a/shared/eventsHub.js
+++ b/shared/eventsHub.js
@@ -3,6 +3,26 @@
  */
 
 /**
+ * When there's a one time subscription, a wrapper function is created with a special property
+ * to identify it and remove it once it gets triggered. The wrapper and the original function
+ * are stored in case `off` is called before the wrapper gets triggered; it will receive the
+ * original function, not the wrapper, so the class needs a way to map them together.
+ *
+ * @typedef {Object} EventsHubWrapperInfo
+ * @property {Function} wrapper  The wrapper function that was created for the subscription.
+ * @property {Function} original The original listener that was sent.
+ * @ignore
+ */
+
+/**
+ * @callback EventsHubOnceWrapper
+ * @param {...*} args The parameters for the original listener.
+ * @returns {*}
+ * @property {boolean} [once=true] A flag so the class will identify the wrapper.
+ * @ignore
+ */
+
+/**
  * A minimal implementation of an events handler service.
  *
  * @parent module:shared/eventsHub
@@ -18,6 +38,16 @@ class EventsHub {
      * @ignore
      */
     this._events = {};
+    /**
+     * A dictionary of wrappers that were created for "one time subscriptions". This is used
+     * by the {@link EventsHub#off}: if it doesn't find the subscriber as it is, it will look
+     * for a wrapper and remove it.
+     *
+     * @type {Object.<string,EventsHubWrapperInfo[]>}
+     * @access protected
+     * @ignore
+     */
+    this._onceWrappers = {};
   }
   /**
    * Emits an event and call all its listeners.
@@ -56,11 +86,36 @@ class EventsHub {
     const events = isArray ? event : [event];
     const result = events.map((name) => {
       const subscribers = this.subscribers(name);
+      const onceSubscribers = this._onceWrappers[name];
       let found = false;
-      const index = subscribers.indexOf(fn);
+      let index = subscribers.indexOf(fn);
       if (index > -1) {
         found = true;
+        /**
+         * If the listener had the `once` flag, then it's a wrapper, so it needs to remove it
+         * from the wrappers list too.
+         *
+         * @ignore
+         */
+        if (fn.once && onceSubscribers) {
+          const wrapperIndex = onceSubscribers.findIndex((item) => item.wrapper === fn);
+          onceSubscribers.splice(wrapperIndex, 1);
+        }
         subscribers.splice(index, 1);
+      } else if (this._onceWrappers[name]) {
+        /**
+         * If it couldn't found the subscriber, maybe it's because it's the original listener
+         * of a wrapper.
+         *
+         * @ignore
+         */
+        index = onceSubscribers.findIndex((item) => item.original === fn);
+        if (index > -1) {
+          found = true;
+          const originalIndex = subscribers.indexOf(onceSubscribers[index].original);
+          subscribers.splice(originalIndex, 1);
+          onceSubscribers.splice(index, 1);
+        }
       }
 
       return found;
@@ -92,12 +147,52 @@ class EventsHub {
    * @param {string|string[]} event An event name or a list of them.
    * @param {Function}        fn    The listener function.
    * @returns {Function} An unsubscribe function to remove the listener.
-   * @todo Use a wrapper instead of modifying the listener.
    */
   once(event, fn) {
-    // eslint-disable-next-line no-param-reassign
-    fn.once = true;
-    return this.on(event, fn);
+    const events = Array.isArray(event) ? event : [event];
+    // Try to find an existing wrapper.
+    let wrapper = events.reduce(
+      (acc, name) => {
+        let nextAcc;
+        if (acc) {
+          // A previous iteration found a wrapper, so `continue`.
+          nextAcc = acc;
+        } else if (this._onceWrappers[name]) {
+          // A list of wrappers exists for the event, so, let's try an find one for this function.
+          const existing = this._onceWrappers[name].find((item) => item.original === fn);
+          if (existing) {
+            nextAcc = existing.wrapper;
+          } else {
+            nextAcc = null;
+          }
+        } else {
+          // The list didn't even exists, let's at least create it.
+          this._onceWrappers[name] = [];
+          nextAcc = null;
+        }
+
+        return nextAcc;
+      },
+      null,
+    );
+    // No wrapper was found, so let's create one.
+    if (!wrapper) {
+      /**
+       * A simple wrapper for the original listener.
+       *
+       * @type {EventsHubOnceWrapper}
+       */
+      wrapper = (...args) => fn(...args);
+      wrapper.once = true;
+      events.forEach((name) => {
+        this._onceWrappers[name].push({
+          wrapper,
+          original: fn,
+        });
+      });
+    }
+
+    return this.on(event, wrapper);
   }
   /**
    * Reduces a target using an event. It's like emit, but the events listener return

--- a/tests/browser/simpleStorage.test.js
+++ b/tests/browser/simpleStorage.test.js
@@ -1,4 +1,5 @@
 jest.unmock('../../browser/simpleStorage');
+jest.unmock('../../shared/deepAssign');
 
 const SimpleStorage = require('../../browser/simpleStorage');
 

--- a/tests/node/logger.test.js
+++ b/tests/node/logger.test.js
@@ -181,6 +181,23 @@ describe('Logger', () => {
     expect(colors[color]).toHaveBeenCalledWith(message);
   });
 
+  it('should log a warning message (yellow) using the `warn` alias', () => {
+    // Given
+    const message = 'Something is not working';
+    const color = 'yellow';
+    const log = jest.fn();
+    spyOn(console, 'log').and.callFake(log);
+    let sut = null;
+    // When
+    sut = new Logger();
+    sut.warn(message);
+    // Then
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith(message);
+    expect(colors[color]).toHaveBeenCalledTimes(1);
+    expect(colors[color]).toHaveBeenCalledWith(message);
+  });
+
   it('should log a success message (green)', () => {
     // Given
     const message = 'Everything works!';

--- a/tests/shared/deepAssign.test.js
+++ b/tests/shared/deepAssign.test.js
@@ -61,6 +61,9 @@ describe('DeepAssign', () => {
       b: 'B',
       [keyOne]: {
         d: 'D',
+        [keyTwo]: {
+          f: 'F',
+        },
       },
       [keyTwo]: 'E',
     };
@@ -84,6 +87,9 @@ describe('DeepAssign', () => {
       [keyOne]: {
         d: 'D',
         dd: 'DD',
+        [keyTwo]: {
+          f: 'F',
+        },
       },
       [keyTwo]: 'E',
     });

--- a/tests/shared/eventsHub.test.js
+++ b/tests/shared/eventsHub.test.js
@@ -100,6 +100,22 @@ describe('EventsHub', () => {
     expect(subscriber).toHaveBeenCalledTimes(1);
   });
 
+  it('shouldn\'t allow a subscriber to subscribe \'once\' more than one time', () => {
+    // Given
+    const eventOneName = 'FIRST EVENT';
+    const eventTwoName = 'SECOND EVENT';
+    const eventNames = [eventOneName, eventTwoName];
+    const subscriber = jest.fn();
+    // When
+    const sut = new EventsHub();
+    sut.once(eventOneName, subscriber);
+    sut.once(eventNames, subscriber);
+    eventNames.forEach((eventName) => sut.emit(eventName));
+    eventNames.forEach((eventName) => sut.emit(eventName));
+    // Then
+    expect(subscriber).toHaveBeenCalledTimes(eventNames.length);
+  });
+
   it('should allow a subscriber to get unsubscribed after executed on multiple events', () => {
     // Given
     const eventOneName = 'FIRST EVENT';
@@ -153,6 +169,24 @@ describe('EventsHub', () => {
     sut.emit(eventOneName);
     // Then
     expect(subscriber).toHaveBeenCalledTimes(eventNames.length);
+  });
+
+  it('should allow a subscriber to unsubscribe before beign triggered (`once`)', () => {
+    // Given
+    const eventName = 'THE EVENT';
+    const subscriberOne = jest.fn();
+    const subscriberTwo = jest.fn();
+    let unsubscribeOne = null;
+    // When
+    const sut = new EventsHub();
+    unsubscribeOne = sut.once(eventName, subscriberOne);
+    unsubscribeOne();
+    sut.once(eventName, subscriberTwo);
+    sut.off(eventName, subscriberTwo);
+    sut.emit(eventName);
+    // Then
+    expect(subscriberOne).toHaveBeenCalledTimes(0);
+    expect(subscriberTwo).toHaveBeenCalledTimes(0);
   });
 
   it('should allow new subscribers for reduced events (number)', () => {

--- a/utils/scripts/todo
+++ b/utils/scripts/todo
@@ -1,2 +1,2 @@
 #!/bin/bash -e
-leasot node/**/*.js shared/**/*.js -x
+leasot browser/**/*.js node/**/*.js shared/**/*.js -x


### PR DESCRIPTION
### What does this PR do?

- Adds `/browser` to the `leasot` script.
- Implements `deepAssign` on `SimpleStorage`; the dependency of `extend` has been limited to `ObjectUtils` (for now).
- `EventsHub` now uses wrappers for the `once` listeners, instead of adding the property to the received function.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```
