### PR TITLE
fix: make all class properties private/protected with public getters

### DIFF
--- a/node/environmentUtils.js
+++ b/node/environmentUtils.js
@@ -30,14 +30,18 @@ class EnvironmentUtils {
      * The current `NODE_ENV`. If the variable is empty, the value will be `development`.
      *
      * @type {string}
+     * @access protected
+     * @ignore
      */
-    this.env = this.get('NODE_ENV', 'development');
+    this._env = this.get('NODE_ENV', 'development');
     /**
      * Whether or not the environment is production.
      *
      * @type {boolean}
+     * @access protected
+     * @ignore
      */
-    this.production = this.env === 'production';
+    this._production = this.env === 'production';
   }
   /**
    * Checks whether an environment variable exists or not.
@@ -101,7 +105,27 @@ class EnvironmentUtils {
    * @type {boolean}
    */
   get development() {
-    return !this.production;
+    return !this._production;
+  }
+  /**
+   * The current `NODE_ENV`. If the variable is empty, the value will be `development`.
+   *
+   * @type {string}
+   * @access protected
+   * @ignore
+   */
+  get env() {
+    return this._env;
+  }
+  /**
+   * Whether or not the environment is production.
+   *
+   * @type {boolean}
+   * @access protected
+   * @ignore
+   */
+  get production() {
+    return this._production;
   }
 }
 /**

--- a/node/errorHandler.js
+++ b/node/errorHandler.js
@@ -52,20 +52,26 @@ class ErrorHandler {
      * A local reference for the `appLogger` service.
      *
      * @type {Logger}
+     * @access protected
+     * @ignore
      */
-    this.appLogger = appLogger;
+    this._appLogger = appLogger;
     /**
      * Whether or not to exit the process after receiving an error.
      *
      * @type {boolean}
+     * @access protected
+     * @ignore
      */
-    this.exitOnError = exitOnError;
+    this._exitOnError = exitOnError;
     /**
      * The list of events this handler will listen for in order to catch errors.
      *
      * @type {string[]}
+     * @access protected
+     * @ignore
      */
-    this.eventsNames = [
+    this._eventsNames = [
       'uncaughtException',
       'unhandledRejection',
     ];
@@ -85,9 +91,9 @@ class ErrorHandler {
    */
   handle(error) {
     // If the logger is configured to show the time...
-    if (this.appLogger.showTime) {
+    if (this._appLogger.showTime) {
       // ...just send the error.
-      this.appLogger.error(error);
+      this._appLogger.error(error);
     } else {
       // ...otherwise, get the time on a readable format.
       const time = new Date()
@@ -97,11 +103,11 @@ class ErrorHandler {
       // Build the error message with the time.
       const message = `[${time}] ${error.message}`;
       // Log the new message with the exception.
-      this.appLogger.error(message, error);
+      this._appLogger.error(message, error);
     }
 
     // Check if it should exit the process.
-    if (this.exitOnError) {
+    if (this._exitOnError) {
       // eslint-disable-next-line no-process-exit
       process.exit(1);
     }
@@ -110,7 +116,7 @@ class ErrorHandler {
    * Starts listening for unhandled errors.
    */
   listen() {
-    this.eventsNames.forEach((eventName) => {
+    this._eventsNames.forEach((eventName) => {
       process.on(eventName, this.handler);
     });
   }
@@ -118,9 +124,17 @@ class ErrorHandler {
    * Stops listening for unhandled errors.
    */
   stopListening() {
-    this.eventsNames.forEach((eventName) => {
+    this._eventsNames.forEach((eventName) => {
       process.removeListener(eventName, this.handler);
     });
+  }
+  /**
+   * Whether or not the process will exit after receiving an error.
+   *
+   * @type {boolean}
+   */
+  get exitOnError() {
+    return this._exitOnError;
   }
 }
 /**

--- a/node/logger.js
+++ b/node/logger.js
@@ -84,14 +84,18 @@ class Logger {
      * The prefix to include in front of all the messages.
      *
      * @type {string}
+     * @access protected
+     * @ignore
      */
-    this.messagesPrefix = messagesPrefix;
+    this._messagesPrefix = messagesPrefix;
     /**
      * Whether or not to show the time on each message.
      *
      * @type {boolean}
+     * @access protected
+     * @ignore
      */
-    this.showTime = showTime;
+    this._showTime = showTime;
     /**
      * An alias for the {@link Logger#warning} method.
      *
@@ -227,6 +231,22 @@ class Logger {
    */
   warning(message) {
     this.log(message, 'yellow');
+  }
+  /**
+   * The prefix to include in front of all the messages.
+   *
+   * @type {string}
+   */
+  get messagesPrefix() {
+    return this._messagesPrefix;
+  }
+  /**
+   * Whether or not to show the time on each message.
+   *
+   * @type {boolean}
+   */
+  get showTime() {
+    return this._showTime;
   }
   /**
    * Gets a function to modify the color of a string. The reason for this _"proxy method"_ is that

--- a/node/pathUtils.js
+++ b/node/pathUtils.js
@@ -35,14 +35,18 @@ class PathUtils {
      * The root path from where the app is being executed.
      *
      * @type {string}
+     * @access protected
+     * @ignore
      */
-    this.path = process.cwd();
+    this._path = process.cwd();
     /**
      * A dictionary of different path locations.
      *
      * @type {Object.<string,string>}
+     * @access protected
+     * @ignore
      */
-    this.locations = {};
+    this._locations = {};
 
     this._addAppLocation();
     this.addLocation('home', home || this.path);
@@ -120,6 +124,26 @@ class PathUtils {
    */
   get home() {
     return this.getLocation('home');
+  }
+  /**
+   * A dictionary of different path locations.
+   *
+   * @type {Object.<string,string>}
+   * @access protected
+   * @ignore
+   */
+  get locations() {
+    return this._locations;
+  }
+  /**
+   * The root path from where the app is being executed.
+   *
+   * @type {string}
+   * @access protected
+   * @ignore
+   */
+  get path() {
+    return this._path;
   }
   /**
    * Finds and register the location for the app executable directory.

--- a/shared/apiClient.js
+++ b/shared/apiClient.js
@@ -110,32 +110,47 @@ class APIClient {
      * The API entry point.
      *
      * @type {string}
+     * @access protected
+     * @ignore
      */
-    this.url = url;
+    this._url = url;
     /**
      * A dictionary of named endpoints relative to the API entry point.
      *
      * @type {Object.<string,(string|APIClientEndpoint)>}
+     * @access protected
+     * @ignore
      */
-    this.endpoints = this.flattenEndpoints(endpoints);
+    this._endpoints = ObjectUtils.flat(
+      endpoints,
+      '.',
+      '',
+      (ignore, value) => typeof value.path === 'undefined',
+    );
     /**
      * The fetch function that makes the requests.
      *
      * @type {APIClientFetchClient}
+     * @access protected
+     * @ignore
      */
-    this.fetchClient = fetchClient;
+    this._fetchClient = fetchClient;
     /**
      * A dictionary of default headers to include on every request.
      *
      * @type {APIClientParametersDictionary}
+     * @access protected
+     * @ignore
      */
-    this.defaultHeaders = defaultHeaders;
+    this._defaultHeaders = defaultHeaders;
     /**
      * An authorization token to include on the requests.
      *
      * @type {string}
+     * @access protected
+     * @ignore
      */
-    this.authorizationToken = '';
+    this._authorizationToken = '';
   }
   /**
    * Makes a `DELETE` request.
@@ -161,7 +176,7 @@ class APIClient {
    */
   endpoint(name, parameters = {}) {
     // Get the endpoint information.
-    const info = this.endpoints[name];
+    const info = this._endpoints[name];
     // Validate that the endpoint exists.
     if (!info) {
       throw new Error(`Trying to request unknown endpoint: ${name}`);
@@ -208,7 +223,7 @@ class APIClient {
       }
     });
     // Convert the URL into a `urijs` object.
-    const uri = urijs(`${this.url}/${path}`);
+    const uri = urijs(`${this._url}/${path}`);
     // Loop and add all the query string parameters.
     Object.keys(query).forEach((queryName) => {
       uri.addQuery(queryName, query[queryName]);
@@ -277,7 +292,7 @@ class APIClient {
 
     let responseStatus;
     // Make the request.
-    return this.fetchClient(url, opts)
+    return this._fetchClient(url, opts)
     .then((response) => {
       // Capture the response status.
       responseStatus = response.status;
@@ -309,21 +324,6 @@ class APIClient {
     ));
   }
   /**
-   * Takes a dictionary of endpoints and flatten them on a single level.
-   * The method just calls {@link ObjectUtils.flat}.
-   *
-   * @param {APIClientEndpoints} endpoints A dictionary of named endpoints.
-   * @returns {Object.<string,(string|APIClientEndpoint)>}
-   */
-  flattenEndpoints(endpoints) {
-    return ObjectUtils.flat(
-      endpoints,
-      '.',
-      '',
-      (ignore, value) => typeof value.path === 'undefined',
-    );
-  }
-  /**
    * Makes a `GET` request.
    *
    * @param {string}                url          The request URL.
@@ -352,9 +352,9 @@ class APIClient {
    * @returns {Object.<string,(string|number)>}
    */
   headers(overwrites = {}) {
-    const headers = { ...this.defaultHeaders };
-    if (this.authorizationToken) {
-      headers.Authorization = `Bearer ${this.authorizationToken}`;
+    const headers = { ...this._defaultHeaders };
+    if (this._authorizationToken) {
+      headers.Authorization = `Bearer ${this._authorizationToken}`;
     }
 
     return { ...headers, ...overwrites };
@@ -404,7 +404,7 @@ class APIClient {
    *                            any token previously saved.
    */
   setAuthorizationToken(token = '') {
-    this.authorizationToken = token;
+    this._authorizationToken = token;
   }
   /**
    * Sets the default headers for the requests.
@@ -415,10 +415,50 @@ class APIClient {
    *                                                         ones.
    */
   setDefaultHeaders(headers = {}, overwrite = true) {
-    this.defaultHeaders = {
-      ...(overwrite ? {} : this.defaultHeaders),
+    this._defaultHeaders = {
+      ...(overwrite ? {} : this._defaultHeaders),
       ...headers,
     };
+  }
+  /**
+   * An authorization token to include on the requests.
+   *
+   * @type {string}
+   */
+  get authorizationToken() {
+    return this._authorizationToken;
+  }
+  /**
+   * A dictionary of default headers to include on every request.
+   *
+   * @type {APIClientParametersDictionary}
+   */
+  get defaultHeaders() {
+    return { ...this._defaultHeaders };
+  }
+  /**
+   * A dictionary of named endpoints relative to the API entry point.
+   *
+   * @type {Object.<string,(string|APIClientEndpoint)>}
+   */
+  get endpoints() {
+    return { ...this._endpoints };
+  }
+  /**
+   * The fetch function that makes the requests.
+   *
+   * @type {APIClientFetchClient}
+   */
+  get fetchClient() {
+    return this._fetchClient;
+  }
+  /**
+   * The API entry point.
+   *
+   * @type {string}
+   */
+  get url() {
+    return this._url;
   }
 }
 

--- a/shared/deepAssign.js
+++ b/shared/deepAssign.js
@@ -94,7 +94,7 @@ class DeepAssign {
    * @type {Readonly<DeepAssignOptions>}
    */
   get options() {
-    return Object.freeze(this._options);
+    return { ...this._options };
   }
   /**
    * Checks if an object is a plain `Object` and not an instance of some class.

--- a/tests/node/appConfiguration.test.js
+++ b/tests/node/appConfiguration.test.js
@@ -51,12 +51,10 @@ describe('AppConfiguration', () => {
     sut = new AppConfiguration(environmentUtils, rootRequire);
     // Then
     expect(sut).toBeInstanceOf(AppConfiguration);
-    expect(sut.environmentUtils).toBe(environmentUtils);
-    expect(sut.rootRequire).toBe(rootRequire);
     expect(sut.options).toEqual(expectedDefaults.options);
     expect(sut.configurations).toEqual(expectedDefaults.configurations);
     expect(sut.activeConfiguration).toBe(expectedDefaults.activeConfiguration);
-    expect(sut.allowConfigurationSwitch).toBe(expectedDefaults.allowConfigurationSwitch);
+    expect(sut.canSwitch).toBe(expectedDefaults.allowConfigurationSwitch);
   });
 
   it('should load a new configuration', () => {
@@ -77,7 +75,7 @@ describe('AppConfiguration', () => {
     expect(result).toEqual(newConfigSettings);
     expect(sut.configurations[newConfigName]).toEqual(newConfigSettings);
     expect(sut.activeConfiguration).toBe(newConfigName);
-    expect(sut.allowConfigurationSwitch).toBe(true);
+    expect(sut.canSwitch).toBe(true);
   });
 
   it('should load a new configuration without switch to it', () => {
@@ -132,7 +130,7 @@ describe('AppConfiguration', () => {
     expect(sut.configurations[newConfigOneName]).toEqual(newConfigOneSettings);
     expect(sut.configurations[newConfigTwoName]).toEqual(expectedConfig);
     expect(sut.activeConfiguration).toBe(newConfigTwoName);
-    expect(sut.allowConfigurationSwitch).toBe(false);
+    expect(sut.canSwitch).toBe(false);
   });
 
   it('should throw an error when trying to extend an unknown configuration', () => {
@@ -172,7 +170,7 @@ describe('AppConfiguration', () => {
     expect(result).toEqual(newConfigSettings);
     expect(sut.configurations[newConfigName]).toEqual(newConfigSettings);
     expect(sut.activeConfiguration).toBe(newConfigName);
-    expect(sut.allowConfigurationSwitch).toBe(true);
+    expect(sut.canSwitch).toBe(true);
     expect(rootRequire).toHaveBeenCalledTimes(1);
     expect(rootRequire).toHaveBeenCalledWith(expectedFileInfo.path);
   });
@@ -235,7 +233,7 @@ describe('AppConfiguration', () => {
     expect(sut.configurations[newConfigOneName]).toEqual(newConfigOneSettings);
     expect(sut.configurations[newConfigTwoName]).toEqual(expectedConfig);
     expect(sut.activeConfiguration).toBe(newConfigTwoName);
-    expect(sut.allowConfigurationSwitch).toBe(false);
+    expect(sut.canSwitch).toBe(false);
     expect(rootRequire).toHaveBeenCalledTimes([
       newConfigOneName,
       newConfigTwoName,
@@ -284,7 +282,7 @@ describe('AppConfiguration', () => {
     expect(result).toEqual(newConfigSettings);
     expect(sut.configurations[newConfigName]).toEqual(newConfigSettings);
     expect(sut.activeConfiguration).toBe(newConfigName);
-    expect(sut.allowConfigurationSwitch).toBe(true);
+    expect(sut.canSwitch).toBe(true);
     expect(rootRequire).toHaveBeenCalledTimes(1);
     expect(rootRequire).toHaveBeenCalledWith(expectedFileInfo.path);
   });
@@ -709,10 +707,10 @@ describe('AppConfiguration', () => {
     sut = new AppConfiguration(environmentUtils, rootRequire);
     sut.load(newConfigOneName, newConfigOneSettings);
     resultAfterLoad = sut.getConfig();
-    canSwitchAfterLoad = sut.canSwitch();
+    canSwitchAfterLoad = sut.canSwitch;
     sut.switch(newConfigTwoName);
     resultAfterSwitch = sut.getConfig();
-    canSwitchAfterSwitch = sut.canSwitch();
+    canSwitchAfterSwitch = sut.canSwitch;
     // Then
     expect(resultAfterLoad).toEqual(newConfigOneSettings);
     expect(canSwitchAfterLoad).toBe(true);
@@ -737,12 +735,13 @@ describe('AppConfiguration', () => {
     // Then
     expect(serviceName).toBe('appConfiguration');
     expect(sut).toBeInstanceOf(AppConfiguration);
-    expect(sut.environmentUtils).toBe('environmentUtils');
-    expect(sut.rootRequire).toBe('rootRequire');
     expect(sut.options).toEqual(expectedDefaults.options);
     expect(sut.configurations).toEqual(expectedDefaults.configurations);
     expect(sut.activeConfiguration).toBe(expectedDefaults.activeConfiguration);
-    expect(sut.allowConfigurationSwitch).toBe(expectedDefaults.allowConfigurationSwitch);
+    expect(sut.canSwitch).toBe(expectedDefaults.allowConfigurationSwitch);
+    expect(container.get).toHaveBeenCalledTimes(2);
+    expect(container.get).toHaveBeenNthCalledWith(1, 'environmentUtils');
+    expect(container.get).toHaveBeenNthCalledWith(2, 'rootRequire');
   });
 
   it('should allow custom options on its service provider', () => {
@@ -772,8 +771,6 @@ describe('AppConfiguration', () => {
     // Then
     expect(serviceName).toBe(options.serviceName);
     expect(sut).toBeInstanceOf(AppConfiguration);
-    expect(sut.environmentUtils).toBe(options.services.environmentUtils);
-    expect(sut.rootRequire).toBe('rootRequire');
     expect(sut.options).toEqual({
       defaultConfigurationName: 'default',
       environmentVariable: options.options.environmentVariable,
@@ -782,6 +779,8 @@ describe('AppConfiguration', () => {
     });
     expect(sut.configurations).toEqual(expectedDefaults.configurations);
     expect(sut.activeConfiguration).toBe(expectedDefaults.activeConfiguration);
-    expect(sut.allowConfigurationSwitch).toBe(expectedDefaults.allowConfigurationSwitch);
+    expect(sut.canSwitch).toBe(expectedDefaults.allowConfigurationSwitch);
+    expect(container.get).toHaveBeenCalledTimes(1);
+    expect(container.get).toHaveBeenCalledWith('rootRequire');
   });
 });


### PR DESCRIPTION
### What does this PR do?

As the title says; all classes' properties are now private/protected, with public getter in most cases; those properties that were for dependency injection, are not longer accessible from outside the class.

To be honest, I had EVERYTHING public, and that's hard to maintain because EVERYTHING you touch can potentially be a breaking change.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```