### PR TITLE
fix(shared/deepAssign): handle undefined properties

### DIFF
--- a/shared/deepAssign.js
+++ b/shared/deepAssign.js
@@ -204,10 +204,9 @@ class DeepAssign {
    */
   _resolve(source, target, ignoreArrayMode = false) {
     let result;
-    if (
-      typeof target !== 'undefined' &&
-      typeof source !== 'undefined'
-    ) {
+    const targetIsUndefined = typeof target === 'undefined';
+    const sourceIsUndefined = typeof source === 'undefined';
+    if (!targetIsUndefined && !sourceIsUndefined) {
       if (Array.isArray(target) && Array.isArray(source)) {
         const { arrayMode } = this._options;
         const useMode = ignoreArrayMode && !['merge', 'shallowMerge'].includes(arrayMode) ?
@@ -223,7 +222,7 @@ class DeepAssign {
       } else {
         result = target;
       }
-    } else {
+    } else if (!targetIsUndefined) {
       result = this._resolveFromEmpty(target);
     }
 

--- a/tests/shared/deepAssign.test.js
+++ b/tests/shared/deepAssign.test.js
@@ -52,6 +52,60 @@ describe('DeepAssign', () => {
     expect(result).toEqual(expected);
   });
 
+  it('should merge on top of an object with an undefined property', () => {
+    // Given
+    let undefinedOnA;
+    const targetA = {
+      a: 'A',
+      b: 'B',
+      d: null,
+      undefinedOnA,
+    };
+    const targetB = {
+      b: 'X',
+      c: 'C',
+      e: null,
+    };
+    let sut = null;
+    let result = null;
+    const expected = {
+      ...targetA,
+      ...targetB,
+    };
+    // When
+    sut = new DeepAssign();
+    result = sut.assign(targetA, targetB);
+    // Then
+    expect(result).toEqual(expected);
+  });
+
+  it('should merge an object with an undefined property', () => {
+    // Given
+    const targetA = {
+      a: 'A',
+      b: 'B',
+      d: null,
+    };
+    let undefinedOnB;
+    const targetB = {
+      b: 'X',
+      c: 'C',
+      e: null,
+      undefinedOnB,
+    };
+    let sut = null;
+    let result = null;
+    const expected = {
+      ...targetA,
+      ...targetB,
+    };
+    // When
+    sut = new DeepAssign();
+    result = sut.assign(targetA, targetB);
+    // Then
+    expect(result).toEqual(expected);
+  });
+
   it('should merge two objects with symbols as keys', () => {
     // Given
     const keyOne = Symbol('key 1');


### PR DESCRIPTION
### What does this PR do?

If an object were to have a enumerable property with an `undefiend` value, the `_isPlainObject` method would cause an error as you can't do `Object.getPrototypeOf(undefined)`. This PR fixes it by checking if the source is defined before trying to resolve it.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```