### PR TITLE
fix: import Jimple type the right way

### DIFF
--- a/@types/jimple.module.d.ts
+++ b/@types/jimple.module.d.ts
@@ -25,7 +25,7 @@ declare module 'jimple' {
        * @return {*} The object related to the service or the value of the parameter associated with the key informed
        * @throws If the key does not exist
        */
-      get(key: string): any;
+      get<T=any>(key: string): T;
       /**
        * Defines a new parameter or service.
        * @param {string} key - The key of the parameter or service to be defined

--- a/shared/jimpleFns.js
+++ b/shared/jimpleFns.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @typedef {import('jimple')} Jimple
+ * @typedef {import('jimple').default} Jimple
  * @external Jimple
  * @see https://yarnpkg.com/en/package/jimple
  */
@@ -17,6 +17,7 @@
 /**
  * @callback ProviderRegisterFn
  * @param {Jimple} app  A reference to the dependency injection container.
+ * @returns {Void}
  * @parent module:shared/jimpleFns
  */
 


### PR DESCRIPTION
### What does this PR do?

Another follow up for #82 - I was importing the `typeof` of `Jimple` instead of the actual instance type.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```
